### PR TITLE
The issue with being able to jump in the air is that your velocity is po...

### DIFF
--- a/src/level.lua
+++ b/src/level.lua
@@ -555,7 +555,7 @@ end
 
 function Level:keypressed(key)
     -- taken from sonic physics http://info.sonicretro.org/SPG:Jumping
-    if key == ' ' and not self.player.rebounding then
+    if key == ' ' and not self.player.rebounding and self.player.velocity.y < 105 then
         if self.player.state ~= 'jump' then
             self.player.jumping = true
             self.player.velocity.y = -670


### PR DESCRIPTION
...sitive, and I've found through printing the values to the screen that the max velocity y when on the ground is 105. So, I just included a simple check that makes sure that the player is on the ground. I'm going to have to figure out the exact value that velocity.y reaches though, just in case the value DOES exceed 105. I haven't has any issues playing though, and I haven't been able to jump mid-air since editing this.
