### PR TITLE
Damage text when player hit

### DIFF
--- a/src/nodes/hippy.lua
+++ b/src/nodes/hippy.lua
@@ -17,6 +17,7 @@ function Hippie.new(node, collider)
     hippie.dead = false
     hippie.width = 48
     hippie.height = 48
+	hippie.dmg = 1
 
     hippie.position = {x=node.x, y=node.y}
     hippie.velocity = {x=0, y=0}
@@ -84,6 +85,7 @@ function Hippie:collide(player, dt, mtv_x, mtv_y)
     
     self:hit()
 
+	player.dmgTaken = self.dmg
     player:die()
     player.bb:move(mtv_x, mtv_y)
     player.velocity.y = -450

--- a/src/player.lua
+++ b/src/player.lua
@@ -40,6 +40,12 @@ function Player.new(collider)
     plyr.bb = collider:addRectangle(0,0,18,44)
     plyr:moveBoundingBox()
     plyr.bb.player = plyr -- wat
+	
+	--for damage text
+	plyr.healthText = {x=0, y=0}
+	plyr.healthVel = {x=0, y=0}
+	plyr.health = 100
+	plyr.dmgTaken = 0
 
     return plyr
 end
@@ -178,6 +184,10 @@ function Player:update(dt)
         self:animation():update(dt)
 
     end
+	
+	self.healthText.x = self.healthText.x + self.healthVel.x * dt
+	self.healthVel.y = self.healthVel.y + (300 * dt)
+	self.healthText.y = self.healthText.y + self.healthVel.y * dt
 end
 
 function Player:die()
@@ -188,6 +198,11 @@ function Player:die()
     love.audio.play(love.audio.newSource("audio/hit.wav", "static"))
     self.rebounding = true
     self.invulnerable = true
+	
+	self.healthText.x = self.position.x
+	self.healthText.y = self.position.y
+	self.healthVel.x = math.random(-100, 100)
+	self.healthVel.y = -100
 
     Timer.add(1.5, function() 
         self.invulnerable = false
@@ -219,6 +234,7 @@ end
 function Player:draw()
     if self.flash then
         love.graphics.setColor(255, 0, 0)
+		love.graphics.print('-' .. self.dmgTaken, self.healthText.x, self.healthText.y)
     end
 
     self:animation():draw(self.sheet, math.floor(self.position.x),


### PR DESCRIPTION
added damage text that flies off of the player when hit. This happens at
the beginning of the episode when they are first attacked by the hippies.
In the show the number flies upward, slows, and fades. I tried it that
way first, but it didn't look quite right because of the fact that in
our version the player rebounds when struck. So I made it so that they
fly off and drop towards the ground, as if affected by gravity.

The damage number is set in the hippy's collide function. For furture
enemies, we can do the same.
