### PR TITLE
Prevents player from escaping death ( literally )

### DIFF
--- a/src/level.lua
+++ b/src/level.lua
@@ -287,7 +287,7 @@ function Level:keypressed(key)
         end
     end
 
-    if key == 'escape' then
+    if key == 'escape' and self.player.health ~= 0 then
         Gamestate.switch('pause')
         return
     end


### PR DESCRIPTION
Prevents the user from escaping out of a level after they have died.

Without this, the user can die, quickly hit escape and choose the outerworld map, but as soon as they start a new level, they immediately respawn in the study room anyways.
