### PR TITLE
Converted bridges to floor nodes

### DIFF
--- a/src/maps/deans-closet.tmx
+++ b/src/maps/deans-closet.tmx
@@ -40,47 +40,51 @@
   <object x="625" y="385" width="552" height="20"/>
   <object x="1537" y="385" width="645" height="20"/>
   <object x="2257" y="384" width="1732" height="21"/>
+  <object x="1176" y="144" width="144" height="24"/>
+  <object x="1416" y="264" width="24" height="24"/>
+  <object x="1488" y="312" width="24" height="24"/>
+  <object x="1176" y="72" width="120" height="24"/>
+  <object type="floor" x="2184" y="168" width="72" height="24"/>
  </objectgroup>
  <objectgroup color="#5500ff" name="platform" width="166" height="17">
-  <object type="floor" x="121" y="337" width="47" height="10"/>
-  <object type="floor" x="1" y="289" width="117" height="10"/>
-  <object type="floor" x="121" y="242" width="333" height="13"/>
+  <object type="floor" x="120" y="336" width="48" height="24"/>
+  <object type="floor" x="0" y="288" width="120" height="24"/>
+  <object type="floor" x="120" y="240" width="336" height="24"/>
   <object type="floor" x="217" y="361" width="47" height="11"/>
-  <object type="floor" x="241" y="146" width="45" height="12"/>
-  <object type="floor" x="0" y="192" width="118" height="13"/>
+  <object type="floor" x="240" y="144" width="48" height="24"/>
+  <object type="floor" x="0" y="192" width="120" height="24"/>
   <object type="floor" x="25" y="373" width="45" height="11"/>
   <object type="floor" x="338" y="372" width="45" height="11"/>
-  <object type="floor" x="673" y="240" width="287" height="15"/>
-  <object type="floor" x="961" y="289" width="93" height="15"/>
+  <object type="floor" x="672" y="240" width="288" height="24"/>
+  <object type="floor" x="960" y="288" width="96" height="24"/>
   <object type="floor" x="769" y="227" width="45" height="11"/>
-  <object type="floor" x="817" y="145" width="503" height="16"/>
-  <object x="863" y="73" width="431" height="16"/>
-  <object type="floor" x="1416" y="264" width="25" height="21"/>
-  <object type="floor" x="1487" y="313" width="25" height="21"/>
-  <object type="floor" x="1705" y="98" width="166" height="19"/>
+  <object type="floor" x="816" y="144" width="360" height="24"/>
+  <object x="864" y="72" width="312" height="24"/>
+  <object type="floor" x="2256" y="168" width="264" height="24"/>
+  <object type="floor" x="1704" y="96" width="168" height="24"/>
   <object type="floor" x="1753" y="84" width="45" height="11"/>
-  <object type="floor" x="1584" y="265" width="551" height="13"/>
-  <object type="floor" x="2110" y="97" width="25" height="21"/>
-  <object type="floor" x="1630" y="192" width="72" height="18"/>
-  <object type="floor" x="2112" y="169" width="406" height="18"/>
+  <object type="floor" x="1584" y="264" width="552" height="24"/>
+  <object type="floor" x="2112" y="96" width="24" height="24"/>
+  <object type="floor" x="1632" y="192" width="72" height="24"/>
+  <object type="floor" x="2112" y="168" width="72" height="24"/>
   <object type="floor" x="1898" y="372" width="45" height="11"/>
   <object type="floor" x="1970" y="372" width="45" height="11"/>
   <object type="floor" x="2041" y="372" width="45" height="11"/>
   <object type="floor" x="2400" y="156" width="45" height="11"/>
   <object type="floor" x="2570" y="251" width="45" height="11"/>
-  <object type="floor" x="2375" y="264" width="263" height="18"/>
+  <object type="floor" x="2376" y="264" width="264" height="24"/>
   <object type="floor" x="2834" y="371" width="45" height="11"/>
-  <object type="floor" x="2688" y="241" width="119" height="16"/>
-  <object type="floor" x="2784" y="170" width="167" height="16"/>
-  <object type="floor" x="3000" y="146" width="430" height="14"/>
-  <object type="floor" x="3000" y="242" width="214" height="14"/>
-  <object type="floor" x="3048" y="74" width="23" height="16"/>
-  <object type="floor" x="3241" y="266" width="214" height="14"/>
-  <object type="floor" x="3769" y="170" width="47" height="16"/>
-  <object type="floor" x="3600" y="266" width="359" height="13"/>
+  <object type="floor" x="2688" y="240" width="120" height="24"/>
+  <object type="floor" x="2784" y="168" width="168" height="24"/>
+  <object type="floor" x="3000" y="144" width="432" height="24"/>
+  <object type="floor" x="3000" y="240" width="216" height="24"/>
+  <object type="floor" x="3048" y="72" width="24" height="24"/>
+  <object type="floor" x="3240" y="264" width="216" height="24"/>
+  <object type="floor" x="3768" y="168" width="48" height="24"/>
+  <object type="floor" x="3600" y="264" width="360" height="24"/>
   <object type="floor" x="3649" y="252" width="45" height="11"/>
   <object type="floor" x="3817" y="371" width="45" height="11"/>
-  <object type="floor" x="3889" y="170" width="70" height="15"/>
+  <object type="floor" x="3888" y="168" width="72" height="24"/>
   <object type="floor" x="3505" y="371" width="45" height="11"/>
  </objectgroup>
 </map>

--- a/src/maps/forest3.tmx
+++ b/src/maps/forest3.tmx
@@ -40,17 +40,19 @@
  <objectgroup color="#2228a4" name="platform" width="80" height="18">
   <object x="1800" y="96" width="120" height="24"/>
   <object x="1704" y="96" width="48" height="24"/>
-  <object x="1536" y="120" width="48" height="24"/>
-  <object x="1320" y="72" width="120" height="24"/>
-  <object x="1104" y="168" width="120" height="24"/>
+  <object x="1536" y="120" width="24" height="24"/>
+  <object x="1344" y="72" width="96" height="24"/>
+  <object x="1104" y="168" width="24" height="24"/>
   <object x="816" y="96" width="216" height="24"/>
   <object x="720" y="168" width="120" height="24"/>
-  <object x="600" y="216" width="144" height="24"/>
-  <object x="168" y="168" width="504" height="24"/>
+  <object x="624" y="216" width="120" height="24"/>
+  <object x="168" y="168" width="72" height="24"/>
   <object x="865" y="241" width="34" height="21"/>
   <object x="0" y="240" width="192" height="24"/>
   <object x="1129" y="48" width="34" height="22"/>
   <object x="1213" y="120" width="36" height="24"/>
+  <object x="600" y="168" width="72" height="24"/>
+  <object x="1176" y="168" width="48" height="24"/>
  </objectgroup>
  <objectgroup color="#3999a4" name="floor" width="80" height="18">
   <object x="0" y="312" width="240" height="120"/>
@@ -58,5 +60,10 @@
   <object x="1176" y="312" width="96" height="120"/>
   <object x="1344" y="288" width="216" height="144"/>
   <object x="1680" y="264" width="240" height="168"/>
+  <object x="600" y="216" width="24" height="24"/>
+  <object x="240" y="168" width="360" height="24"/>
+  <object x="1128" y="168" width="48" height="24"/>
+  <object x="1560" y="120" width="24" height="24"/>
+  <object x="1320" y="72" width="24" height="24"/>
  </objectgroup>
 </map>

--- a/src/maps/gay island.tmx
+++ b/src/maps/gay island.tmx
@@ -68,10 +68,9 @@
   <object type="entrance" x="24" y="216" width="24" height="48"/>
   <object type="exit" x="5256" y="0" width="24" height="144"/>
  </objectgroup>
- <objectgroup name="platform" width="220" height="18" visible="0">
-  <object x="264" y="120" width="240" height="24"/>
-  <object x="298" y="242" width="36" height="21"/>
-  <object x="385" y="264" width="36" height="21"/>
+ <objectgroup name="platform" width="220" height="18">
+  <object x="264" y="120" width="72" height="24"/>
+  <object x="288" y="240" width="48" height="24"/>
   <object x="1644" y="241" width="35" height="23"/>
   <object x="1717" y="216" width="34" height="22"/>
   <object x="1225" y="217" width="34" height="21"/>
@@ -88,26 +87,12 @@
   <object x="4992" y="96" width="72" height="24"/>
   <object x="4872" y="240" width="144" height="24"/>
   <object x="4344" y="168" width="144" height="24"/>
-  <object x="583" y="96" width="58" height="22"/>
-  <object x="728" y="144" width="56" height="24"/>
-  <object x="606" y="288" width="59" height="22"/>
-  <object x="752" y="265" width="56" height="22"/>
-  <object x="847" y="190" width="57" height="23"/>
-  <object x="992" y="215" width="56" height="24"/>
-  <object x="2376" y="264" width="168" height="24"/>
-  <object x="2697" y="166" width="52" height="22"/>
-  <object x="2863" y="167" width="57" height="21"/>
-  <object x="2984" y="264" width="56" height="20"/>
-  <object x="3176" y="240" width="56" height="22"/>
-  <object x="3439" y="144" width="58" height="22"/>
-  <object x="3610" y="192" width="28" height="23"/>
-  <object x="3751" y="263" width="57" height="24"/>
-  <object x="3943" y="217" width="56" height="22"/>
-  <object x="4088" y="288" width="55" height="21"/>
+  <object x="2697" y="166" width="39" height="21"/>
   <object x="4762" y="239" width="53" height="24"/>
   <object x="4712" y="71" width="55" height="23"/>
   <object x="4881" y="72" width="29" height="22"/>
-  <object x="5096" y="120" width="31" height="22"/>
+  <object x="408" y="120" width="96" height="24"/>
+  <object x="408" y="264" width="24" height="24"/>
  </objectgroup>
  <objectgroup color="#8e3da4" name="floor" width="220" height="18">
   <object x="0" y="264" width="144" height="168"/>
@@ -116,10 +101,27 @@
   <object x="1080" y="288" width="768" height="144"/>
   <object x="1920" y="336" width="144" height="96"/>
   <object x="2064" y="312" width="96" height="120"/>
-  <object x="2160" y="264" width="216" height="168"/>
+  <object x="2160" y="264" width="576" height="168"/>
   <object x="3312" y="192" width="72" height="240"/>
   <object x="5184" y="144" width="144" height="312"/>
   <object x="4224" y="336" width="864" height="96"/>
-  <object x="2544" y="264" width="192" height="168"/>
+  <object x="336" y="120" width="72" height="24"/>
+  <object x="384" y="264" width="24" height="24"/>
+  <object x="583" y="96" width="58" height="22"/>
+  <object x="606" y="288" width="59" height="22"/>
+  <object x="728" y="144" width="56" height="24"/>
+  <object x="847" y="190" width="57" height="23"/>
+  <object x="752" y="265" width="56" height="22"/>
+  <object x="992" y="215" width="56" height="24"/>
+  <object x="2736" y="166" width="15" height="21"/>
+  <object x="2863" y="167" width="57" height="21"/>
+  <object x="2984" y="264" width="56" height="20"/>
+  <object x="3176" y="240" width="56" height="22"/>
+  <object x="3439" y="144" width="58" height="22"/>
+  <object x="3610" y="192" width="28" height="23"/>
+  <object x="3751" y="263" width="57" height="24"/>
+  <object x="3943" y="217" width="56" height="22"/>
+  <object x="4088" y="288" width="55" height="21"/>
+  <object x="5096" y="120" width="31" height="22"/>
  </objectgroup>
 </map>

--- a/src/maps/gay island2.tmx
+++ b/src/maps/gay island2.tmx
@@ -2,9 +2,9 @@
 <map version="1.0" orientation="orthogonal" width="80" height="18" tilewidth="24" tileheight="24">
  <properties>
   <property name="offset" value="6"/>
+  <property name="soundtrack" value="pocketfull"/>
   <property name="title" value="Gay Island 2"/>
   <property name="warpin" value="true"/>
-  <property name="soundtrack" value="pocketfull"/>
  </properties>
  <tileset firstgid="1" name="gay island1" tilewidth="24" tileheight="24">
   <image source="gay island1.png" width="624" height="624"/>
@@ -69,21 +69,28 @@
   <object x="1008" y="240" width="72" height="192"/>
   <object x="720" y="360" width="168" height="72"/>
   <object x="0" y="288" width="648" height="144"/>
+  <object x="918" y="289" width="58" height="23"/>
+  <object x="1111" y="311" width="57" height="24"/>
+  <object x="648" y="168" width="72" height="24"/>
+  <object x="888" y="168" width="24" height="24"/>
+  <object x="984" y="168" width="24" height="24"/>
+  <object x="1200" y="144" width="24" height="24"/>
  </objectgroup>
  <objectgroup color="#4a3ea4" name="platform" width="80" height="18">
-  <object x="408" y="168" width="624" height="24"/>
-  <object x="1200" y="144" width="288" height="24"/>
+  <object x="408" y="168" width="240" height="24"/>
+  <object x="1224" y="144" width="264" height="24"/>
   <object x="1241" y="72" width="204" height="24"/>
   <object x="1536" y="96" width="120" height="24"/>
   <object x="1584" y="168" width="168" height="24"/>
   <object x="1833" y="240" width="54" height="22"/>
   <object x="1428" y="265" width="34" height="22"/>
-  <object x="1111" y="311" width="57" height="24"/>
-  <object x="918" y="289" width="58" height="23"/>
   <object x="877" y="96" width="34" height="23"/>
   <object x="108" y="216" width="35" height="24"/>
   <object x="275" y="240" width="37" height="23"/>
   <object x="432" y="73" width="34" height="22"/>
+  <object x="720" y="168" width="168" height="24"/>
+  <object x="912" y="168" width="72" height="24"/>
+  <object x="1008" y="168" width="24" height="24"/>
  </objectgroup>
  <objectgroup name="nodes" width="80" height="18">
   <object type="exit" x="1896" y="0" width="24" height="312"/>

--- a/src/nodes/floor.lua
+++ b/src/nodes/floor.lua
@@ -58,15 +58,9 @@ function Floor:collide(player, dt, mtv_x, mtv_y)
         return
     end
 
-    if mtv_y ~= 0 then
+    if mtv_y < 0 then
         player.velocity.y = 0
         player.position.y = wy1 - player.height
-        updatePlayer()
-    end
-
-    if mtv_x ~= 0 then
-        player.velocity.x = 0
-        player.position.x = player.position.x + mtv_x
         updatePlayer()
     end
 end


### PR DESCRIPTION
Changed floor collision detection

This change converts all platforms that are directly over pits into floors. This required removal of the x collision detection from floor, which means that when you fall into a pit, you don't bounce off the walls. Also, the Y collision detection was changed to only push back on a user that is above, so that the user doesn't snap up when they touch the object.

Fixes #138
