### PR TITLE
#80. Fix rendering bug

### DIFF
--- a/src/level.lua
+++ b/src/level.lua
@@ -269,7 +269,7 @@ function Level:quit()
 end
 
 function Level:draw()
-    self.map:autoDrawRange(camera.x * -1, camera.y, 1, 0)
+    self.map:autoDrawRange(camera.x * -1, -camera.y, 1, 0)
     self.map:draw()
 
     for i,node in ipairs(self.nodes) do


### PR DESCRIPTION
The fix turned out to be super-simple, but it took freaking forever to track down.

In my own personal testing, I noticed some levels rendering slightly slower than they did before, which implies that some render size settings may have been optimized for the broken code, but idk. Coulda just been a hoggy background process that decided to run at the same time.
