### PR TITLE
Walls are now fully blocking

### DIFF
--- a/src/nodes/wall.lua
+++ b/src/nodes/wall.lua
@@ -6,6 +6,7 @@ function Wall.new(node, collider)
     setmetatable(wall, Wall)
     wall.bb = collider:addRectangle(node.x, node.y, node.width, node.height)
     wall.bb.node = wall
+    wall.node = node
     collider:setPassive(wall.bb)
 
     return wall
@@ -17,9 +18,15 @@ function Wall:collide(player, dt, mtv_x, mtv_y)
         player.position.x = player.position.x + mtv_x
     end        
 
-    if mtv_y ~= 0 then
+    if mtv_y > 0 then
         player.velocity.y = 0
         player.position.y = player.position.y + mtv_y
+    end
+    
+    if mtv_y < 0 then
+        player.velocity.y = 0
+        player.position.y = self.node.y - player.height
+        player.jumping = false
     end
 end
 


### PR DESCRIPTION
This is so we can use walls in sidescrolling levels like the black caverns.

Changes will not effect the wall node's behavior in any of the floorspace levels
