### PR TITLE
Rewrote a bunch of code for holding objects

### DIFF
--- a/src/nodes/baseball.lua
+++ b/src/nodes/baseball.lua
@@ -128,9 +128,6 @@ function Baseball:moveBoundingBox()
 end
 
 function Baseball:pickup(player)
-    player.walk_state = 'holdwalk'
-    player.gaze_state = 'holdwalk'
-    player.crouch_state = 'holdwalk'
     self.held = true
     self.thrown = false
     self.velocity.y = 0
@@ -138,9 +135,6 @@ function Baseball:pickup(player)
 end
 
 function Baseball:throw(player)
-    player.walk_state = 'walk'
-    player.crouch_state = 'crouch'
-    player.gaze_state = 'gaze'
     self.held = false
     self.thrown = true
     self.velocity.x = ( ( ( player.direction == "left" ) and -1 or 1 ) * 500 ) + player.velocity.x
@@ -148,9 +142,6 @@ function Baseball:throw(player)
 end
 
 function Baseball:throw_vertical(player)
-    player.walk_state = 'walk'
-    player.crouch_state = 'crouch'
-    player.gaze_state = 'gaze'
     self.held = false
     self.thrown = true
     self.velocity.x = player.velocity.x
@@ -158,9 +149,6 @@ function Baseball:throw_vertical(player)
 end
 
 function Baseball:drop(player)
-    player.walk_state = 'walk'
-    player.crouch_state = 'crouch'
-    player.gaze_state = 'gaze'
     self.held = false
     self.thrown = true
     self.velocity.x = ( ( ( player.direction == "left" ) and -1 or 1 ) * 50 ) + player.velocity.x

--- a/src/nodes/pot.lua
+++ b/src/nodes/pot.lua
@@ -95,18 +95,12 @@ function Pot:moveBoundingBox()
 end
 
 function Pot:pickup(player)
-    player.walk_state = 'holdwalk'
-    player.gaze_state = 'holdwalk'
-    player.crouch_state = 'holdwalk'
     self.held = true
     self.velocity.y = 0
     self.velocity.x = 0
 end
 
 function Pot:throw(player)
-    player.walk_state = 'walk'
-    player.crouch_state = 'crouchwalk'
-    player.gaze_state = 'gazewalk'
     self.held = false
     self.thrown = true
     self.floor = player.position.y + player.height - self.height
@@ -117,9 +111,6 @@ function Pot:throw(player)
 end
 
 function Pot:throw_vertical(player)
-    player.walk_state = 'walk'
-    player.crouch_state = 'crouchwalk'
-    player.gaze_state = 'gazewalk'
     self.held = false
     self.thrown = true
     self.floor = player.position.y + player.height - self.height
@@ -130,9 +121,6 @@ function Pot:throw_vertical(player)
 end
 
 function Pot:drop(player)
-    player.walk_state = 'walk'
-    player.crouch_state = 'crouchwalk'
-    player.gaze_state = 'gazewalk'
     self.held = false
     self.thrown = false
     self.position.y = player.position.y + player.height - self.height

--- a/src/player.lua
+++ b/src/player.lua
@@ -424,6 +424,23 @@ function Player:draw()
 end
 
 ---
+-- Sets the sprite states of a player based on a preset combination
+-- @param presetName
+-- @return nil
+function Player:setSpriteStates(presetName)
+    if presetName == 'holding' then
+        self.walk_state   = 'holdwalk'
+        self.crouch_state = 'holdwalk'
+        self.gaze_state   = 'holdwalk'
+    else
+        -- Default
+        self.walk_state   = 'walk'
+        self.crouch_state = 'crouchwalk'
+        self.gaze_state   = 'gazewalk'
+    end
+end
+
+---
 -- Registers an object as something that the user can currently hold on to
 -- @param holdable
 -- @return nil
@@ -448,6 +465,7 @@ end
 -- @return nil
 function Player:pickup()
     if self.holdable and self.currently_held == nil then
+        self:setSpriteStates('holding')
         self.currently_held = self.holdable
         if self.currently_held.pickup then
             self.currently_held:pickup(self)
@@ -460,6 +478,7 @@ end
 -- @return nil
 function Player:throw()
     if self.currently_held then
+        self:setSpriteStates('default')
         local object_thrown = self.currently_held
         self.currently_held = nil
         if object_thrown.throw then
@@ -473,6 +492,7 @@ end
 -- @return nil
 function Player:throw_vertical()
     if self.currently_held then
+        self:setSpriteStates('default')
         local object_thrown = self.currently_held
         self.currently_held = nil
         if object_thrown.throw_vertical then
@@ -486,6 +506,7 @@ end
 -- @return nil
 function Player:drop()
     if self.currently_held then
+        self:setSpriteStates('default')
         local object_dropped = self.currently_held
         self.currently_held = nil
         if object_dropped.drop then


### PR DESCRIPTION
This should be ridiculously stable now, and easy to make new classes for. At some point we may want some sort of generic "holdable" class or mixin, but that should be pretty reasonable now that there's a better structure to that part of the code.
## Changes to player.lua

The player class now uses the variables `self.currently_held` and `self.holdable` to store, respectively, the object currently being held, and the object you would grab if you were try to pick something up. So, self.holdable is used the same as before, but self.holding is no longer used, traded off for the more descriptively-named and better-used currently_held.

It also contains some new methods, all of them documented.
### setSpriteStates(presetName)

Takes a string "preset name", such as "holding" or "default", and sets some internal variables according to that preset. At present, those variables are walk_state, crouch_state, and gaze_state, although one of the nice things about having that code all in one place is that it would be easy to add more variables to this function's purview, unlike before, where these values were being set by external code all over the place.
### pickup()

Pick up the current self.holdable. This does nothing if you're already holding something, but will set sprite state to "holding" using the above function, set currently_held to holdable, and call currently_held:pickup(self) if the object contains that callback function.
### throw()

Throws the currently held object. Works a lot like pickup(), including setting sprite state to default, and calling the thrown object's "throw" callback if available.
### throw_vertical()

Throw the currently held object straight into the air. You can do this by gazing up and throwing. Callback code is what you'd expect.
### drop()

Can be used to set fragile objects down without injury, drop a baseball to the ground half-heartedly, etc. Callback code is what you'd expect.
## Baseball and Pot

Both of these classes had some surgery on their innards, and no longer listen for keypresses. That job has now been moved to the Player class, along with setting sprite state, so all these classes have to do is provide the optional callbacks dictating their behavior when picked up, thrown, thrown vertically, or dropped. These callbacks mostly involve physics and setting some variables that track internal state.

While I was in there, I also took the liberty of incorporating the player velocity into the object's physics wherever it improved gameplay. There were a few parts where I tried it and it was lame, but those parts I undid before publishing.
## Holding and glancing

One thing that was made obvious during testing is that the wrong sprites are used when looking up or down while holding an object. The animation simply becomes "holdwalk", which doesn't make much sense when you're standing still underneath Cornelius' chin getting ready to pop one straight up at him from underneath. That's probably a fix for another day, though, since it's unrelated to the physics, and was a preexisting problem before I stuck my nose in to fix this bug.
