### PR TITLE
Fall damage.

### DIFF
--- a/src/game.lua
+++ b/src/game.lua
@@ -4,6 +4,7 @@ game.friction = 0.146875 * game.step
 game.accel = 0.046875 * game.step
 game.deccel = 0.5 * game.step
 game.gravity = 0.21875 * game.step
+game.fall_dps = 2
 game.airaccel = 0.09375 * game.step
 game.airdrag = 0.96875 * game.step
 game.max_x = 300

--- a/src/nodes/bouncer.lua
+++ b/src/nodes/bouncer.lua
@@ -19,6 +19,7 @@ end
 function Bouncer:collide(player, dt, mtv_x, mtv_y)
     if player.position.y + player.height > self.node.y + self.node.height then
         sound.playSfx('jump')
+        player.fall_damage = 0
         if self.double_bounce then
             player.velocity.y = self.dbval
         else

--- a/src/nodes/floor.lua
+++ b/src/nodes/floor.lua
@@ -56,6 +56,7 @@ function Floor:collide(player, dt, mtv_x, mtv_y)
         -- fudge the Y a bit to prevent falling into steep angles
         player.position.y = (py1 - 1) + mtv_y
         updatePlayer()
+        player:impactDamage()
         return
     end
 
@@ -63,6 +64,7 @@ function Floor:collide(player, dt, mtv_x, mtv_y)
         player.velocity.y = 0
         player.position.y = wy1 - player.height
         updatePlayer()
+        player:impactDamage()
     end
 
     if mtv_x ~= 0 then

--- a/src/nodes/platform.lua
+++ b/src/nodes/platform.lua
@@ -41,6 +41,7 @@ function Platform:collide(player, dt, mtv_x, mtv_y)
         player:moveBoundingBox()
         player.jumping = false
         player.rebounding = false
+        player:impactDamage()
     end
 
     if self.bb.polyline

--- a/src/player.lua
+++ b/src/player.lua
@@ -46,6 +46,7 @@ function Player.new(collider)
     plyr.actions = {}
     plyr.position = {x=0, y=0}
     plyr.velocity = {x=0, y=0}
+    plyr.fall_damage = 0
     plyr.state = 'idle'       -- default animation is idle
     plyr.direction = 'right'  -- default animation faces right
     plyr.animations = {}
@@ -264,6 +265,7 @@ function Player:update(dt)
 
     if self.velocity.y > game.max_y then
         self.velocity.y = game.max_y
+        self.fall_damage = self.fall_damage + game.fall_dps * dt
     end
     -- end sonic physics
     
@@ -356,6 +358,11 @@ function Player:die(damage)
         return
     end
 
+    damage = math.floor(damage)
+    if damage == 0 then
+        return
+    end
+
     sound.playSfx( "damage_" .. math.max(self.health, 0) )
     self.rebounding = true
     self.invulnerable = true
@@ -378,6 +385,16 @@ function Player:die(damage)
     end)
 
     self:startBlink()
+end
+
+---
+-- Call to take falling damage, and reset self.fall_damage to 0
+-- @return nil
+function Player:impactDamage()
+    if self.fall_damage > 0 then
+        self:die(self.fall_damage)
+    end
+    self.fall_damage = 0
 end
 
 ---


### PR DESCRIPTION
The fall damage mechanism is pretty simple. Any time you're falling at the game's "terminal velocity", you are accumulating potential damage in self.fall_damage. When you hit the ground, this value is rounded down to an integer, so if you have less than 1 in self.fall_damage when you hit, you will incur no damage at all.

Player:die() has been modified to handle floating-point and 0 damage in a reasonable fashion, doing the round-down stuff for you, so you can just throw any crazy number into it now. This makes the new Player:impactDamage() function very concise, which calls self:die(self.fall_damage) and sets self.fall_damage to 0. I also had to dip into the platform, floor, and bouncer nodes to make sure they called Player:impactDamage() at the appropriate times (and only then), and in the case of the bouncer, harmlessly reset Player.fall_damage.

The amount of damage that falling does is configurable in game.lua as the "fall_dps" variable. A fall_dps of 1 means "for every second of terminal velocity, do 1 damage." 2 fall_dps = 2 damage per second. Because this only gets counted when you're at terminal velocity, not total airtime, it ends up being a pretty fair measurement. I've committed with fall_dps=2 because it can be demonstrated in the game in taller levels like the Village Forest, without screwing up existing levels. Basically, if you can see your landing spot before you jump, you'll incur no damage, and even then, you still have a bit of room before you get to the hurt zone.

This won't really have any impact on the game until we start having intentionally tall levels like Treeline.
