### PR TITLE
Enhanced entrances

### DIFF
--- a/src/level.lua
+++ b/src/level.lua
@@ -191,11 +191,16 @@ function Level.new(name)
     level.player.boundary = {width=level.map.width * level.map.tilewidth}
 
     level.nodes = {}
+    level.entrances = {}
 
     level.default_position = {x=0, y=0}
     for k,v in pairs(level.map.objectgroups.nodes.objects) do
         if v.type == 'entrance' then
-            level.default_position = {x=v.x, y=v.y}
+            if v.properties.name then
+                level.entrances[v.properties.name] = {x=v.x, y=v.y}
+            else
+                level.default_position = {x=v.x, y=v.y}
+            end
             level.player.position = level.default_position
         else
             node = load_node(v.type)

--- a/src/maps/gay-island-2.tmx
+++ b/src/maps/gay-island-2.tmx
@@ -82,13 +82,13 @@
    eJztljEOgjAUhh+cxKN4C2HjCuIFHOQcdXbW3cDo4AmacBR/BJMGFh9iStP/S76hSVMeXwKpyPJcFHtv8PqHGUIm5n4mkXPliPVGe4am31PeDVvtM9YKmsnJEeuj9gxNvzXxmPGuY5boFzPsNwUN7t/uNX2z4qNhP1U/MoX9fgPfYOF7BhebyLbB3ajTzrgf+WSXimQwT/3NgG5SDzaB/V/36FbCA/sFi+27tZ2W/QghhETICxxoNSA=
   </data>
  </layer>
- <objectgroup color="#5da431" name="floor" width="80" height="18" visible="0">
+ <objectgroup color="#5da431" name="floor" width="80" height="18">
   <object x="1224" y="312" width="696" height="120"/>
   <object x="1008" y="240" width="72" height="192"/>
   <object x="720" y="360" width="168" height="72"/>
   <object x="0" y="288" width="648" height="144"/>
  </objectgroup>
- <objectgroup color="#4a3ea4" name="platform" width="80" height="18" visible="0">
+ <objectgroup color="#4a3ea4" name="platform" width="80" height="18">
   <object x="408" y="168" width="240" height="24"/>
   <object x="1224" y="144" width="264" height="24"/>
   <object x="1241" y="72" width="204" height="24"/>
@@ -129,7 +129,7 @@
    </properties>
   </object>
  </objectgroup>
- <objectgroup name="nodes" width="80" height="18" visible="0">
+ <objectgroup name="nodes" width="80" height="18">
   <object type="exit" x="1896" y="0" width="24" height="312"/>
   <object type="entrance" x="0" y="240" width="24" height="48"/>
   <object type="liquid" x="312" y="370" width="168" height="72">
@@ -166,6 +166,12 @@
     <property name="opacity" value="0.95"/>
     <property name="speed" value="0.15"/>
     <property name="sprite" value="images/water.png"/>
+   </properties>
+  </object>
+  <object type="door" x="1320" y="24" width="24" height="48">
+   <properties>
+    <property name="entrance" value="nestled"/>
+    <property name="level" value="village-forest"/>
    </properties>
   </object>
  </objectgroup>

--- a/src/maps/village-forest.tmx
+++ b/src/maps/village-forest.tmx
@@ -118,5 +118,10 @@
   <object type="leaf" x="647" y="71" width="24" height="24"/>
   <object type="stick" x="529" y="108" width="24" height="24"/>
   <object type="stick" x="1000" y="-1" width="24" height="24"/>
+  <object type="entrance" x="720" y="48" width="48" height="48">
+   <properties>
+    <property name="name" value="nestled"/>
+   </properties>
+  </object>
  </objectgroup>
 </map>

--- a/src/nodes/door.lua
+++ b/src/nodes/door.lua
@@ -10,8 +10,9 @@ function Door.new(node, collider)
     door.bb.node = door
     door.player_touched = false
     door.level = node.properties.level
-    door.instant = node.properties.instant
-    door.reenter = node.properties.reenter
+    door.instant  = node.properties.instant
+    door.reenter  = node.properties.reenter
+    door.entrance = node.properties.entrance
     collider:setPassive(door.bb)
 
     return door
@@ -37,6 +38,11 @@ function Door:switch(player)
         Gamestate.switch(self.level, current.character)
     else
         Gamestate.switch(self.level)
+    end
+    if self.entrance ~= nil then
+        local level = Gamestate.get(self.level)
+        local coordinates = level.entrances[self.entrance]
+        level.player.position = {x=coordinates.x, y=coordinates.y} -- Copy, or player position corrupts entrance data
     end
 end
 


### PR DESCRIPTION
A very tiny patch that adds support for entrances with a "name" attribute, and doors that can link to them. That way you can have doors to specific parts of the level.

Ultimately, I'd like to move the "warpin" property from the level properties to entrance properties, and work toward deprecating the "reenter" property in favor of entrance naming, but this patch attempts neither. The only changes it adds to the maps, purely for testing/proof of concept, involve linking the door in Gay Island 2 to a spot in the Village Forest (I'm sure we'll want to link that to something else later, but for now, what's the harm?).

Fixes #487.
