### PR TITLE
Fixes #479 (Holdables and throwing knives arguing over controls)

### DIFF
--- a/src/player.lua
+++ b/src/player.lua
@@ -446,10 +446,14 @@ function Player:update( dt )
 
     self.healthText.y = self.healthText.y + self.healthVel.y * dt
 
-    if attacking then 
-        if (not self.prevAttackPressed) then 
+    if attacking then
+        if self:getAction() == 'attack' then
+            if (not self.prevAttackPressed) then 
+                self.prevAttackPressed = true
+                self:attack()
+            end
+        else
             self.prevAttackPressed = true
-            self:attack()
         end
     else
         self.prevAttackPressed = false
@@ -671,6 +675,21 @@ end
 ---
 -- Executes the players weaponless attack (punch, kick, or something like that)
 function Player:defaultAttack()
+end
+
+---
+-- Returns an object indicating what will happen when the action button is pressed
+-- @return action
+function Player:getAction()
+    if self.currently_held then
+        return 'throw'
+    elseif self.holdable then
+        return 'pick up'
+    elseif self.inventory:currentWeapon() then
+        return 'attack'
+    else
+        return 'interact'
+    end
 end
 
 -- Throws an object.


### PR DESCRIPTION
As usual, I tried to solve this with a forward-thinking and consistent system, rather than a short-term hack. Keyboard context solves the majority of control problems when used properly, but there's another layer of player-specific logic necessary to mediate conflicts between the player's use of the action button, 'A' (commonly, SHIFT). This pull request provides that layer of mediation.

I've added a Player:getAction() function, that goes through a few local variables to determine who has "right of way" to respond to the action button, and then spits out a corresponding string (currently-programmed possibilities are "pick up", "throw", "interact", and "attack"). At some point we'll want to add NPC conversation-starting logic to that, and handle the deferred control during the conversation using keyboard context. Long-term, this will help us solve the "keyboard logic is all over the damn place" problem. This specific patch only goes far enough to solve the specific problem detailed in #479, where throwing knives are conflicting with holdables.
