### PR TITLE
Patch that fixes issues starting game in specific levels

### DIFF
--- a/src/hud.lua
+++ b/src/hud.lua
@@ -14,7 +14,7 @@ function HUD.new( level )
     setmetatable(hud, HUD)
         
     hud.sheet = level.character.sheet
-    hud.character_quad = love.graphics.newQuad( 0, level.character.offset, 48, 48, hud.sheet:getWidth(), hud.sheet:getHeight() )
+    hud.character_quad = love.graphics.newQuad( 0, level.character.offset or 5, 48, 48, hud.sheet:getWidth(), hud.sheet:getHeight() )
     
     hud.character_stencil = function( x, y )
         love.graphics.circle( 'fill', x + 31, y + 31, 21 )

--- a/src/level.lua
+++ b/src/level.lua
@@ -263,6 +263,9 @@ function Level:enter(previous, character)
         self.previous = previous
         self:restartLevel()
     end
+    if not self.player then
+        self:restartLevel()
+    end
 
     camera.max.x = self.map.width * self.map.tilewidth - window.width
 


### PR DESCRIPTION
Some recent change broke our ability to start the game in arbitrary levels based on command line flags. This patch makes it work again. It's hacky voodoo and superstition but it works, somehow. Needs a better fix later, but this is kind of an urgent thing for some people.
