### PR TITLE
fixed black caverns ducking error

### DIFF
--- a/src/nodes/wall.lua
+++ b/src/nodes/wall.lua
@@ -54,7 +54,7 @@ end
 
 function Wall:collide_end( node ,dt )
     if node.isPlayer then
-        player.wall_duck = false
+        node.wall_duck = false
     end
 end
 


### PR DESCRIPTION
fixes a node error in black caverns with an illegitimate reference to player.
