### PR TITLE
Fix Issue #213 -- Unexpected character change after dying

### DIFF
--- a/src/level.lua
+++ b/src/level.lua
@@ -309,7 +309,12 @@ function Level:update(dt)
         self.over = true
         self.respawn = Timer.add(3, function() 
             Gamestate.get('overworld'):reset()
-            Gamestate.switch(Level.new(self.spawn), self.character)
+            local spawnLevel = Gamestate.get(self.spawn)
+            if spawnLevel then
+                Gamestate.switch(spawnLevel, self.character)
+            else
+                Gamestate.switch(Level.new(self.spawn), self.character)
+            end
         end)
     end
 


### PR DESCRIPTION
When respawning was creating new instance of studyroom level instead of reusing existing one which would throw off which character was being used when returning to study room via door.
