### PR TITLE
make.bat now determines if tmx2lua is in the path correctly

### DIFF
--- a/src/level.lua
+++ b/src/level.lua
@@ -309,12 +309,7 @@ function Level:update(dt)
         self.over = true
         self.respawn = Timer.add(3, function() 
             Gamestate.get('overworld'):reset()
-            local spawnLevel = Gamestate.get(self.spawn)
-            if spawnLevel then
-                Gamestate.switch(spawnLevel, self.character)
-            else
-                Gamestate.switch(Level.new(self.spawn), self.character)
-            end
+            Gamestate.switch(Level.new(self.spawn), self.character)
         end)
     end
 


### PR DESCRIPTION
With this fix, tmx2lua doesn't have to be in your current directory to be referenced, just in your path(which includes the current directory, unless you set your path strangely) Original code was (in a way) not looking at the right environment variable with contained the found tmx2lua file within the path, so it mistakenly could never find tmx2lua at all.
