### PR TITLE
Adds debugger ( again )

### DIFF
--- a/src/debugger.lua
+++ b/src/debugger.lua
@@ -1,0 +1,71 @@
+local List = require 'list'
+local window = require 'window'
+local fonts = require 'fonts'
+
+local Debugger = { on=false }
+Debugger.__index = Debugger
+
+Debugger.sampleRate = 0.05
+Debugger.lastSample = 0
+
+Debugger.graphData = {
+  { name = 'gc', color = { 255, 0, 0, 150 }, list = List.new() }
+}
+
+function Debugger:reset()
+  for k,_ in pairs(Debugger.graphData) do
+      Debugger.graphData[k].list = List.new()
+  end
+end
+
+function Debugger:toggle()
+  Debugger.on = not Debugger.on
+  Debugger:reset()
+end
+
+function Debugger:getData(name)
+  for k,v in pairs(Debugger.graphData) do
+    if v.name == name then
+      return Debugger.graphData[k]
+    end
+  end
+  return false
+end
+
+function Debugger:listPush( list, val )
+  List.pushleft( list, val )
+  if math.abs(list.first) - math.abs(list.last) > window.screen_width then
+    List.popright( list )
+  end
+end
+
+function Debugger:update( dt )
+    if Debugger.on and Debugger.lastSample > Debugger.sampleRate then
+        Debugger:listPush( Debugger:getData('gc').list, collectgarbage( 'count' ) / 100 )
+        Debugger.lastSample = 0
+    else
+        Debugger.lastSample = Debugger.lastSample + dt
+    end
+end
+
+function Debugger:draw()
+  for k,v in pairs( Debugger.graphData ) do
+    love.graphics.setColor( v.color )
+    for i=v.list.first, v.list.last do
+      if v.list[i] then
+        love.graphics.line(
+          window.screen_width + v.list.first - i,
+          window.screen_height - v.list[i],
+          window.screen_width + v.list.first - i,
+          window.screen_height
+        )
+      end
+    end
+  end
+  love.graphics.setColor( 255, 255, 255, 255 )
+  fonts.set('big')
+  love.graphics.print( math.floor( collectgarbage( 'count' ) / 10 ) / 10 , window.screen_width - 30, window.screen_height - 10,0,0.5,0.5 )
+  fonts.revert()
+end
+
+return Debugger

--- a/src/list.lua
+++ b/src/list.lua
@@ -1,0 +1,36 @@
+List = {}
+function List.new ()
+  return {first = 0, last = -1}
+end
+
+function List.pushleft (list, value)
+  local first = list.first - 1
+  list.first = first
+  list[first] = value
+end
+    
+function List.pushright (list, value)
+  local last = list.last + 1
+  list.last = last
+  list[last] = value
+end
+    
+function List.popleft (list)
+  local first = list.first
+  if first > list.last then error("list is empty") end
+  local value = list[first]
+  list[first] = nil        -- to allow garbage collection
+  list.first = first + 1
+  return value
+end
+    
+function List.popright (list)
+  local last = list.last
+  if list.first > last then error("list is empty") end
+  local value = list[last]
+  list[last] = nil         -- to allow garbage collection
+  list.last = last - 1
+  return value
+end
+
+return List

--- a/src/main.lua
+++ b/src/main.lua
@@ -2,6 +2,7 @@ local correctVersion = require 'correctversion'
 if correctVersion then
 
   require 'utils'
+  local debugger = require 'debugger'
   local Gamestate = require 'vendor/gamestate'
   local Level = require 'level'
   local camera = require 'camera'
@@ -33,6 +34,7 @@ if correctVersion then
     cli:add_option("-c, --character=NAME", "The character to use in the game")
     cli:add_option("-o, --costume=NAME", "The costume to use in the game")
     cli:add_option("-m, --mute=CHANNEL", "Disable sound: all, music, sfx")
+    cli:add_option("-d, --debug", "Enable Memory Debugger")
     cli:add_option("--console", "Displays print info")
 
     local args = cli:parse(arg)
@@ -54,12 +56,15 @@ if correctVersion then
     end
     
     if args["mute"] == 'all' then
-      sound.volume('music',0)
-      sound.volume('sfx',0)
+      sound.disabled = true
     elseif args["mute"] == 'music' then
       sound.volume('music',0)
     elseif args["mute"] == 'sfx' then
       sound.volume('sfx',0)
+    end
+    
+    if args["d"] then
+        debugger.on = true
     end
 
     love.graphics.setDefaultImageFilter('nearest', 'nearest')
@@ -71,6 +76,7 @@ if correctVersion then
 
   function love.update(dt)
     if paused then return end
+    if debugger.on then debugger:update(dt) end
     dt = math.min(0.033333333, dt)
     Gamestate.update(dt)
     sound.cleanup()
@@ -82,6 +88,7 @@ if correctVersion then
   end
 
   function love.keypressed(key)
+    if key == 'f5' then debugger:toggle() end
     local button = controls.getButton(key)
     if button then Gamestate.keypressed(button) end
   end
@@ -98,6 +105,7 @@ if correctVersion then
       love.graphics.setColor(255, 255, 255, 255)
     end
 
+    if debugger.on then debugger:draw() end
   end
 
   -- Override the default screenshot functionality so we can disable the fps before taking it

--- a/src/nodes/airplane.lua
+++ b/src/nodes/airplane.lua
@@ -79,7 +79,9 @@ function Airplane:update(dt, player)
     if self.node.x < -self.noiseRadius then
         self.node.x = self.map.width * self.map.tilewidth + self.noiseRadius
     end
-    self.engineNoise.x = self.node.x
+    if self.engineNoise then
+        self.engineNoise.x = self.node.x
+    end
 end
 
 function Airplane:draw()

--- a/src/vendor/TEsound.lua
+++ b/src/vendor/TEsound.lua
@@ -133,10 +133,12 @@ end
 
 TEsound.musicPlaying = nil
 TEsound.proxiData = {}
+TEsound.disabled = false
 
 -- Registers the new music, if it's not already
 -- Stops any currently playing music
 function TEsound.playMusic( song )
+    if TEsound.disabled then return end
 	if string.find( song, 'audio/' ) ~= 1 then -- not a path
 		song = 'audio/music/' .. song .. '.ogg'
 	end
@@ -149,11 +151,13 @@ function TEsound.playMusic( song )
 end
 
 function TEsound.stopMusic()
+    if TEsound.disabled then return end
 	TEsound.stop( 'music' )
 	TEsound.musicPlaying = nil
 end
 
 function TEsound.playSfx( sound, x, y, r )
+    if TEsound.disabled then return end
     -- plays a sound effect
     -- if x, y, and r are specified, then the volume will be adjusted for proximity to the player
 	if string.find( sound , 'audio/' ) ~= 1 then -- not a path
@@ -164,6 +168,7 @@ function TEsound.playSfx( sound, x, y, r )
 end
 
 function TEsound.startSfx( sound, n, x, y, r )
+    if TEsound.disabled then return false end
     -- starts a sound effect looping ( either infinately or n times )
     -- if x, y, and r are specified, then the volume will be adjusted for proximity to the player
 	if string.find( sound , 'audio/' ) ~= 1 then -- not a path
@@ -182,6 +187,7 @@ function TEsound.startSfx( sound, n, x, y, r )
 end
 
 function TEsound.stopSfx( sound )
+    if TEsound.disabled then return end
     -- stops sound based on proxidata or all sound effects
     if sound then
         for i,v in ipairs( TEsound.channels ) do
@@ -196,10 +202,12 @@ function TEsound.stopSfx( sound )
 end
 
 function TEsound.getSource( sound )
+    if TEsound.disabled then return end
 	return love.audio.newSource(sound)
 end
 
 function TEsound.getProximityVol( x, y, r )
+    if TEsound.disabled then return end
     local vol
     if x and y and r then
         pos = ( require 'vendor/gamestate' ).currentState().player.position
@@ -209,7 +217,7 @@ function TEsound.getProximityVol( x, y, r )
 end
 
 function TEsound.adjustProximityVolumes()
-
+    if TEsound.disabled then return end
     -- this function should be called by player and is used to adjust all looping proximity sound effects
     for i,v in ipairs( TEsound.findTag( 'sfx' ) ) do
         local s = TEsound.channels[v]


### PR DESCRIPTION
Disabled by default
Enable with the -d or --debug flag or in game toggle with f5
Also changed the --mute=all flag to disable sound completely to assist in debugging

This should allow us to easily debug screens that have memory leaks

It's definitely not an end-all be-all debugger, but it should suffice for the time being until we have time to find a more robust solution, at which point we can axe this.

![stable / leaky](http://i.imgur.com/2bVLi.png)
