### PR TITLE
Make the default prompt and menu items return true when button pressed

### DIFF
--- a/src/dialog.lua
+++ b/src/dialog.lua
@@ -65,6 +65,8 @@ function Dialog:keypressed( button )
             self.state = 'closing'
         end
     end
+
+    return true
 end
 
 

--- a/src/level.lua
+++ b/src/level.lua
@@ -395,17 +395,21 @@ function Level:keyreleased( button )
 end
 
 function Level:keypressed( button )
-    if button == 'START' and not self.player.dead then
-        Gamestate.switch('pause')
-        return
-    end
-    
-    self.player:keypressed( button, self )
-
     for i,node in ipairs(self.nodes) do
         if node.player_touched and node.keypressed then
-            node:keypressed( button, self.player)
+            if node:keypressed( button, self.player) then
+              return true
+            end
         end
+    end
+   
+    if self.player:keypressed( button, self ) then
+      return true
+    end
+
+    if button == 'START' and not self.player.dead then
+        Gamestate.switch('pause')
+        return true
     end
 end
 

--- a/src/nodes/dealer.lua
+++ b/src/nodes/dealer.lua
@@ -36,10 +36,11 @@ end
 
 function Dealer:keypressed( button, player )
     if self.prompt then
-        self.prompt:keypressed( button )
+        return self.prompt:keypressed( button )
     end
+
     if self.dialog then
-        self.dialog:keypressed(button)
+        return self.dialog:keypressed(button)
     end
     
     if button == 'ACTION' and player.money == 0 and self.dialog == nil then
@@ -48,6 +49,7 @@ function Dealer:keypressed( button, player )
             player.freeze = false
             self.dialog = nil
         end)
+        return true
     elseif button == 'ACTION' and player.money > 0 and self.prompt == nil then
         player.freeze = true
         self.prompt = Prompt.new(140, 65, "Choose your game:", function(result)
@@ -63,6 +65,7 @@ function Dealer:keypressed( button, player )
             end
             self.prompt = nil
         end, {'Poker','Blackjack','Close'} )
+        return true
     end
 end
 

--- a/src/nodes/info.lua
+++ b/src/nodes/info.lua
@@ -46,7 +46,7 @@ end
 
 function Info:keypressed( button, player )
     if self.dialog then
-        self.dialog:keypressed(button)
+        return self.dialog:keypressed(button)
     end
     
     if button == 'ACTION' and self.dialog == nil and not player.freeze then
@@ -55,6 +55,7 @@ function Info:keypressed( button, player )
             player.freeze = false
             self.dialog = nil
         end)
+        return true
     end
 end
 

--- a/src/nodes/npc.lua
+++ b/src/nodes/npc.lua
@@ -27,7 +27,7 @@ end
 function Menu:keypressed( button, player )
     if self.dialog and (self.state == 'closed' or self.state == 'hidden')
         and button == 'ACTION' then
-        self.dialog:keypressed( button, player )
+        return self.dialog:keypressed( button, player )
     end
 
     if self.state == 'closed' or self.state == 'hidden' then
@@ -66,9 +66,10 @@ function Menu:keypressed( button, player )
         end
     elseif button == 'JUMP' then
         self:close()
-        player.jumping = true
         player.freeze = false
     end
+
+    return true
 end
 
 
@@ -264,28 +265,26 @@ function Npc:moveBoundingBox()
 end
 
 function Npc:keypressed( button, player )
-    if button == 'ACTION' and self.menu.state == 'closed' and not player.jumping then
-        player.freeze = true
-        player.character.state = 'idle'
-        self.state = 'standing'
-     if player.position.x < self.position.x then
-             self.direction = 'left'
-             player.character.direction = 'right'
-             self.position.x = player.position.x+30
-        else
-             self.direction = 'right'
-             player.character.direction = 'left'
-             self.position.x = player.position.x-30
-        end
+  if button == 'ACTION' and self.menu.state == 'closed' and not player.jumping then
+    player.freeze = true
+    player.character.state = 'idle'
+    self.state = 'standing'
 
-        self:moveBoundingBox()
-
-        self.menu:open()
+    if player.position.x < self.position.x then
+      self.direction = 'left'
+      player.character.direction = 'right'
+      self.position.x = player.position.x+30
+    else
+      self.direction = 'right'
+      player.character.direction = 'left'
+      self.position.x = player.position.x-30
     end
 
-    if player.freeze then
-        self.menu:keypressed( button, player )
-    end
+    self:moveBoundingBox()
+    self.menu:open()
+  end
+  
+  return self.menu:keypressed( button, player )
 end
 
 return Npc

--- a/src/prompt.lua
+++ b/src/prompt.lua
@@ -90,7 +90,6 @@ function Prompt:keypressed( button )
 
     if button == 'ACTION' then
         self.board:close()
-        return true
     end
 
     if button == 'LEFT' then
@@ -111,7 +110,7 @@ function Prompt:keypressed( button )
         end
     end
 
-    return button == 'UP' or button == 'RIGHT' or button == 'LEFT' or button == 'DOWN'
+    return true
 end
 
 return Prompt


### PR DESCRIPTION
It's pretty simple. If a node returns true from a keypressed event, no other node (or player) will get that keypress. Say goodbye to multiple menus popping up at the same time
