### PR TITLE
Lookup later

### DIFF
--- a/src/level.lua
+++ b/src/level.lua
@@ -426,19 +426,29 @@ function Level:leave()
     end
 end
 
-function Level:keyreleased( button )
-    if (button == 'DOWN' or button == 'UP') and self.pan_timer then
-      if self.pan_tween ~= nil then Tween.stop(self.pan_tween) end
+function Level:cancelLookup()
+    if self.pan_timer then
+      if self.pan_tween ~= nil then 
+        Tween.stop(self.pan_tween)
+      end
+
+      self.player:setSpriteStates('default')
+
       Tween(self.pan_time, self, {pan = 0})
       Timer.cancel(self.pan_timer)
       self.pan_timer = nil
       self.pan_tween = nil
     end
+end
 
+function Level:keyreleased( button )
+    self:cancelLookup()
     self.player:keyreleased( button, self )
 end
 
 function Level:keypressed( button )
+    self:cancelLookup()
+
     if button == 'START' and not self.player.dead then
         Gamestate.switch('pause')
         return
@@ -447,6 +457,7 @@ function Level:keypressed( button )
     if button == 'UP' or button == 'DOWN' then
       self.pan_timer = Timer.add(self.pan_delay, function()
         local d = button == 'UP' and -self.pan_distance or self.pan_distance
+        self.player:setSpriteStates('lookingup')
         self.pan_tween = Tween(self.pan_time, self, {pan = d})
       end)
     end

--- a/src/player.lua
+++ b/src/player.lua
@@ -591,7 +591,7 @@ function Player:setSpriteStates(presetName)
             self.gaze_state   = 'gazewalk'
         else
             self.crouch_state = 'crouch'
-            self.gaze_state   = 'gaze'
+            self.gaze_state   = 'idle'
         end
         self.jump_state   = 'wieldjump'
         self.idle_state   = 'wieldidle'
@@ -602,7 +602,7 @@ function Player:setSpriteStates(presetName)
             self.gaze_state   = 'holdwalk'
         else
             self.crouch_state = 'crouch'
-            self.gaze_state   = 'gaze'
+            self.gaze_state   = 'idle'
         end
         self.jump_state   = 'holdjump'
         self.idle_state   = 'hold'
@@ -618,6 +618,17 @@ function Player:setSpriteStates(presetName)
         self.gaze_state   = 'gazewalk'
         self.jump_state   = 'gazewalk'
         self.idle_state   = 'gazeidle'
+    elseif presetName == 'lookingup' then
+        self.walk_state   = 'walk'
+        if self.footprint then
+            self.crouch_state = 'crouchwalk'
+            self.gaze_state   = 'gazewalk'
+        else
+            self.crouch_state = 'crouch'
+            self.gaze_state   = 'gaze'
+        end
+        self.jump_state   = 'jump'
+        self.idle_state   = 'idle'
     elseif presetName == 'default' then
         -- Default
         self.walk_state   = 'walk'
@@ -626,7 +637,7 @@ function Player:setSpriteStates(presetName)
             self.gaze_state   = 'gazewalk'
         else
             self.crouch_state = 'crouch'
-            self.gaze_state   = 'gaze'
+            self.gaze_state   = 'idle'
         end
         self.jump_state   = 'jump'
         self.idle_state   = 'idle'


### PR DESCRIPTION
Characters only lookup when the camera pans. This is better because when you enter doors or pick up items, you no longer see the character lookup for a fraction of a second.
