### PR TITLE
Fix levelpanning overwriting playerstate each frame

### DIFF
--- a/src/level.lua
+++ b/src/level.lua
@@ -478,13 +478,19 @@ function Level:updatePan(dt)
     end
 
     if up and self.pan_hold_up >= self.pan_delay then
-        self.player:setSpriteStates('looking')
+        if self.player.current_state_set ~= 'looking' then
+            self.player:setSpriteStates('looking')
+        end
         self.pan = math.max( self.pan - dt * self.pan_speed, -self.pan_distance )
     elseif down and self.pan_hold_down >= self.pan_delay then
-        self.player:setSpriteStates('looking')
+        if self.player.current_state_set ~= 'looking' then
+            self.player:setSpriteStates('looking')
+        end
         self.pan = math.min( self.pan + dt * self.pan_speed, self.pan_distance )
     else
-        self.player:setSpriteStates('default')
+        if self.player.current_state_set == 'looking' then
+            self.player:setSpriteStates(self.player.previous_state_set)
+        end
         if self.pan > 0 then
             self.pan = math.max( self.pan - dt * self.pan_speed, 0 )
         elseif self.pan < 0 then


### PR DESCRIPTION
*ommitted unnecessary player state changes in the level panning this fixes the problem of the attack animation being truncated because this would set the sprite states each frame to either
'looking' or 'default', effectively truncating all other states.

This is a hotfix, consider choosing https://github.com/kyleconroy/hawkthorne-journey/pull/739 instead if the structural changes that it proposes are more apt.
