### PR TITLE
Keeps money and inventory on death

### DIFF
--- a/src/player.lua
+++ b/src/player.lua
@@ -72,8 +72,8 @@ function Player:refreshPlayer(collider)
     --changes that are made if you're dead
     if self.dead then
         self.health = self.max_health
-        self.money = 0
-        self.inventory = Inventory.new( self )
+        --self.money = 0
+        --self.inventory = Inventory.new( self )
         self.lives = self.lives - 1
     end
     


### PR DESCRIPTION
Per a suggestion on Reddit, I commented out the lines that reset the money and inventory on death.

This change is temporary until we have the levels reset, but it makes the game more fun to not have death be a full wipe of loot you can't go back and get again.

Game over and player switching still resets the inventory/money as usual.
