### PR TITLE
Return after setting sound to nil in TEsound.stopSfx

### DIFF
--- a/src/vendor/TEsound.lua
+++ b/src/vendor/TEsound.lua
@@ -194,6 +194,7 @@ function TEsound.stopSfx( sound )
             if v[1] == sound.src then
                 TEsound.stop( i )
                 sound = nil
+                return
             end
         end
     else


### PR DESCRIPTION
Fixes issue #654

The loop would continue to run and check sound.src == v[1] even after it was stopped and set to nil.
