### PR TITLE
manicorn charging up tweaks

### DIFF
--- a/src/nodes/enemies/manicorn.lua
+++ b/src/nodes/enemies/manicorn.lua
@@ -90,6 +90,7 @@ return {
     end,
     update = function( dt, enemy, player, level )
         if enemy.state == 'dying' then return end
+        enemy.jumpkill = (enemy.state == 'attackrainbow_charging')
 
         if enemy.state == 'default' and math.abs(player.position.y-enemy.position.y) < 100
              and math.abs(player.position.x-enemy.position.x) < 300 then
@@ -106,6 +107,7 @@ return {
         local too_close = false
         if enemy.state == 'attack' or string.find(enemy.state,'attackrainbow') then
             if enemy.state == 'attackrainbow_start' then
+                enemy.direction = enemy.position.x < player.position.x and 'right' or 'left'
                 if enemy.currently_held then
                     enemy.state = 'attackrainbow_charging'
                     enemy.currently_held:launch(enemy)
@@ -115,7 +117,7 @@ return {
                 end
             end
         
-            if math.abs(enemy.position.x - player.position.x)<offset then
+            if math.abs(enemy.position.x - player.position.x)<offset or enemy.state == 'attackrainbow_charging'then
                 too_close = true
             elseif enemy.position.x < player.position.x then
                 enemy.direction = 'right'


### PR DESCRIPTION
manicorns are susceptible to jumpkills when they're charging up their beams

manicorn direction stays fixed during charge up

This had been requested once or twice before, so I figured I'd try to sneak it in.
