### PR TITLE
screen no longer shifts size at startup

### DIFF
--- a/src/conf.lua
+++ b/src/conf.lua
@@ -3,8 +3,8 @@ function love.conf(t)
     t.author            = "Kyle Conroy"
     t.version           = "0.8.0"
     t.identity          = "hawkthorne"
-    t.screen.width      = 912
-    t.screen.height     = 528
+    t.screen.width      = 1056
+    t.screen.height     = 672
     t.screen.fullscreen = false
     t.console           = false
     t.modules.physics   = false


### PR DESCRIPTION
This closes #609

I had noticed this a while ago, but hadn't sent a pull request because the bug this references seems non-critical.
