### PR TITLE
Make drumsticks scroll both directions

### DIFF
--- a/src/maps/black-caverns.tmx
+++ b/src/maps/black-caverns.tmx
@@ -83,7 +83,7 @@
     <property name="chain" value="5"/>
     <property name="drop" value="false"/>
     <property name="line" value="drumsticks"/>
-    <property name="singleuse" value="true"/>
+    <property name="singleuse" value="false"/>
     <property name="speed" value="0.5"/>
     <property name="sprite" value="images/drumstick.png"/>
     <property name="start" value="0"/>


### PR DESCRIPTION
Changed the value of the property "singleuse" from true to false for the drumsticks on the black-caverns map.
