### PR TITLE
allows tmx2lua in working directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ win64/*
 redditors.txt
 src/maps/*.lua
 venv
+tmx2lua*
 bin/*
 release.md
 post.md


### PR DESCRIPTION
until we rewrite the windows batch file we should leave tmx2lua in our .gitignore
