### PR TITLE
dequips a weapon when going to the overworld

### DIFF
--- a/src/pause.lua
+++ b/src/pause.lua
@@ -7,6 +7,7 @@ local controls = require 'controls'
 local state = Gamestate.new()
 local VerticalParticles = require "verticalparticles"
 local Timer = require 'vendor/timer'
+local Player = require 'player'
 
 
 function state:init()
@@ -78,6 +79,12 @@ function state:keypressed( button )
         elseif self.option == 1 then
             Gamestate.switch('options')
         elseif self.option == 2 then
+            local player = Player.factory()
+            if player.currently_held and player.currently_held.unuse then
+                player.currently_held:unuse('sound_off')
+            elseif player.currently_held then
+                player:drop()
+            end
             Gamestate.switch('overworld')
         elseif self.option == 3 then
             self.previous:quit()


### PR DESCRIPTION
So the naming of Player.factory() would probably be more appropriately called Player.load() but this essentially fixes the double weapon bug. Will find a related issue #.

Explanation: before this bug fix, if you took out a weapon in forest-1, exit to overworld and return to forest-1, you'd see your previous weapon in your hand but you wouldn't be able to use it. Equipping a second weapon would make it appear over the first one.
