### PR TITLE
fix .love association on os x

### DIFF
--- a/osx/Info.plist
+++ b/osx/Info.plist
@@ -6,35 +6,6 @@
 	<string>12C54</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
-	<key>CFBundleDocumentTypes</key>
-	<array>
-		<dict>
-			<key>CFBundleTypeIconFile</key>
-			<string>LoveDocument.icns</string>
-			<key>CFBundleTypeName</key>
-			<string>LÖVE Project</string>
-			<key>CFBundleTypeRole</key>
-			<string>Viewer</string>
-			<key>LSHandlerRank</key>
-			<string>Owner</string>
-			<key>LSItemContentTypes</key>
-			<array>
-				<string>org.love2d.love-game</string>
-			</array>
-		</dict>
-		<dict>
-			<key>CFBundleTypeName</key>
-			<string>Folder</string>
-			<key>CFBundleTypeOSTypes</key>
-			<array>
-				<string>fold</string>
-			</array>
-			<key>CFBundleTypeRole</key>
-			<string>Viewer</string>
-			<key>LSHandlerRank</key>
-			<string>None</string>
-		</dict>
-	</array>
 	<key>CFBundleExecutable</key>
 	<string>love</string>
 	<key>CFBundleIconFile</key>
@@ -48,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleSignature</key>
-	<string>LoVe</string>
+	<string>HaWk</string>
 	<key>CFBundleVersion</key>
 	<string>0.0.1</string>
 	<key>DTCompiler</key>
@@ -69,34 +40,6 @@
 	<string>© 2006-2012 LÖVE Development Team</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
-	<key>UTExportedTypeDeclarations</key>
-	<array>
-		<dict>
-			<key>UTTypeConformsTo</key>
-			<array>
-				<string>com.pkware.zip-archive</string>
-			</array>
-			<key>UTTypeDescription</key>
-			<string>LÖVE Project</string>
-			<key>UTTypeIconFile</key>
-			<string>LoveDocument.icns</string>
-			<key>UTTypeIdentifier</key>
-			<string>org.love2d.love-game</string>
-			<key>UTTypeReferenceURL</key>
-			<string>http://love2d.org/wiki/Game_Distribution</string>
-			<key>UTTypeTagSpecification</key>
-			<dict>
-				<key>com.apple.ostype</key>
-				<string>LOVE</string>
-				<key>public.filename-extension</key>
-				<array>
-					<string>love</string>
-				</array>
-				<key>public.mime-type</key>
-				<string>application/x-love-game</string>
-			</dict>
-		</dict>
-	</array>
 	<key>SUFeedURL</key>
 	<string>http://files.projecthawkthorne.com/appcast.xml</string>
 	<key>SUPublicDSAKeyFile</key>


### PR DESCRIPTION
This appears to get rid of the .love association on os x. It looks like the upstream docs (https://love2d.org/wiki/Game_Distribution#Mac_OS_X) are terribly incomplete; I'll see about getting those fixed.
