### PR TITLE
Fixes tween dt = 0 error

### DIFF
--- a/src/main.lua
+++ b/src/main.lua
@@ -129,7 +129,7 @@ if correctVersion then
     if debugger.on then debugger:update(dt) end
     dt = math.min(0.033333333, dt)
     Gamestate.update(dt)
-    tween.update(dt)
+    tween.update(dt > 0 and dt or 0.001)
     timer.update(dt)
     sound.cleanup()
   end


### PR DESCRIPTION
Error: vendor/tween.lua:360: dt must be a positive number
