### PR TITLE
Add application object for storing configuration information

### DIFF
--- a/src/app.lua
+++ b/src/app.lua
@@ -1,0 +1,2 @@
+local app = require 'hawk/application'
+return app.new('config.json')

--- a/src/config.json
+++ b/src/config.json
@@ -1,0 +1,3 @@
+{
+  "mixpanel": "ac1c2db50f1332444fd0cafffd7a5543"
+}

--- a/src/hawk/application.lua
+++ b/src/hawk/application.lua
@@ -1,0 +1,18 @@
+local json = require 'hawk/json'
+
+local application = {}
+application.__index = application
+
+function application.new(configurationPath)
+  local app = {}
+  setmetatable(app, application)
+
+  assert(love.filesystem.exists(configurationPath), "Can't read app configuration")
+  
+  local contents, _  = love.filesystem.read(configurationPath)
+  app.config = json.decode(contents)
+
+  return app
+end
+
+return application

--- a/src/main.lua
+++ b/src/main.lua
@@ -4,6 +4,7 @@ if correctVersion then
 
   require 'utils'
   local i18n = require 'hawk/i18n'
+  local app = require 'app'
 
   local tween = require 'vendor/tween'
   local Gamestate = require 'vendor/gamestate'


### PR DESCRIPTION
This is only the first use of the `app` object. Asset loading, i18n,
gamesaves, and scene management are all planning on going through the
app object.

``` lua
local app = require 'hawk/appication'

-- asset manager
app.manager

-- user preferences, simple key-value store
app.preferences

-- really needed?
app.gamesaves

-- configuration
app.configuration

-- configured i18n
app.i18n
```

In your src/app.lua

``` lua
local app = require 'hawk/appication'
return app.new()
```
