### PR TITLE
ATTACK is set as the default 'ok' button

### DIFF
--- a/src/dialog.lua
+++ b/src/dialog.lua
@@ -105,7 +105,7 @@ function Dialog:keypressed( button )
         return false
     end
 
-    if button == 'JUMP' then
+    if button == 'ATTACK' then
         if self.cursor < string.len(self.messages[self.line]) then
             self.cursor = string.len(self.messages[self.line])
         elseif self.line ~= #self.messages then


### PR DESCRIPTION
This is part of my push to ensure we're using some UI standard. Button mashing might make sense, but good games should have consistent controls. I'm trying very hard not to assume the controls I'm used to are the correct controls for the game
