### PR TITLE
prevents the user from entering doors when inventory is open

### DIFF
--- a/src/level.lua
+++ b/src/level.lua
@@ -528,13 +528,14 @@ end
 
 function Level:keypressed( button )
     if self.state ~= 'active' then
-        return
+        return true
     end
 
-    --i don't know why it makes sense for us to be still to interact...
-    if button == 'INTERACT' and not self.player:isIdleState(self.player.character.state) then
-        return
+    if self.player.inventory.visible then
+        self.player.inventory:keypressed( button )
+        return true
     end
+
 
     --uses a copy of the nodes to eliminate a concurrency error
     local tmpNodes = self:copyNodes()

--- a/src/player.lua
+++ b/src/player.lua
@@ -223,10 +223,6 @@ function Player:switchWeapon()
 end
 
 function Player:keypressed( button, map )
-    if self.inventory.visible then
-        self.inventory:keypressed( button )
-        return
-    end
     
     if button == 'SELECT' and not self.interactive_collide then
         if self.currently_held and self.currently_held.wield and controls.isDown( 'DOWN' )then


### PR DESCRIPTION
also allows the user to press interact while he/she is moving

So you can run towards npcs and hit `INTERACT` in motion to talk to them
