### PR TITLE
shortened the player's top bounding box

### DIFF
--- a/src/player.lua
+++ b/src/player.lua
@@ -153,7 +153,7 @@ function Player:refreshPlayer(collider)
 
     self.attack_box = PlayerAttack.new(collider,self)
     self.collider = collider
-    self.top_bb = collider:addRectangle(0,0,self.bbox_width,1*self.bbox_height/3)
+    self.top_bb = collider:addRectangle(0,0,self.bbox_width,self.bbox_height/3)
     self.bottom_bb = collider:addRectangle(0,self.bbox_height/2,self.bbox_width,self.bbox_height/2)
     self:moveBoundingBox()
     self.top_bb.player = self -- wat


### PR DESCRIPTION
shortened the player's top bounding box and
makes the player stay in the jumping state when his/her head hits the ceiling
