### PR TITLE
npc bounding box no longer detaches from player

### DIFF
--- a/src/nodes/npc.lua
+++ b/src/nodes/npc.lua
@@ -281,6 +281,8 @@ function Npc:keypressed( button, player )
       player.character.direction = 'left'
       self.position.x = player.position.x-width/2
     end
+    self.position.x = self.position.x > self.maxx and self.maxx or self.position.x
+    self.position.x = self.position.x < self.minx and self.minx or self.position.x
 
     self.menu:open()
     return self.menu:keypressed('ATTACK', player )


### PR DESCRIPTION
This was originally going to be designed to fix #1112, but having to choose between having the player overlap with the NPC or moving the player(to a possibly dangerous place) seemed unfair.

This pull request ensures that as a result of talking to an NPC your bounding box doesn't become separated from him/her.
