### PR TITLE
added support for windows users to clear their datastore with "make.ps1 reset"

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -2,6 +2,7 @@ if($args[0] -eq "clean"){
     rm src/maps/*.lua
     return
 }elseif($args[0] -eq "reset"){
+    rm $env:AppData\LOVE\Hawkthorne\*.json
     rm src/maps/*.lua
     rm bin/
     return


### PR DESCRIPTION
pretty much what the title says.

I highly suggest against using this option unless you try one of many workarounds, because some conflict has broken master. Reported in #1196
