### PR TITLE
fixes crash on level start under Windows 7 64

### DIFF
--- a/src/level.lua
+++ b/src/level.lua
@@ -289,7 +289,7 @@ function Level:enter( previous, door, position )
 
     self.hud = HUD.new(self)
 
-    if door then
+    if self.doors[ door ] then
         self.player.position = {
             x = self.doors[ door ].x + self.doors[ door ].node.width / 2 - self.player.width / 2,
             y = self.doors[ door ].y + self.doors[ door ].node.height - self.player.height


### PR DESCRIPTION
Windows 7 64 crashes with...

> Error
> level.lua:294: attempt to index field '?' (a nil value)

...when it is time to enter a level (just after intro "flyin" animation).
This check prevents the crash and only places the character at a door if Level:enter is given a valid door for the level.
