### PR TITLE
Fix tavern stuck behind bar bug

### DIFF
--- a/src/maps/tavern.tmx
+++ b/src/maps/tavern.tmx
@@ -36,7 +36,7 @@
    <properties>
     <property name="height" value="38"/>
    </properties>
-   <polygon points="0,0 165,0 165,-3 20,-3 20,-7 0,-7"/>
+   <polygon points="0,0 165,0 165,-3 20,-3 20,-8 0,-8"/>
   </object>
   <object x="0" y="336">
    <properties>


### PR DESCRIPTION
For bug https://github.com/hawkthorne/hawkthorne-journey/issues/957
The back of the bar was flush with the back of the main floorspace, I think this was allowing the character to get trapped between the two.
I extended the back of the bar 1 pixel further back and I believe it has solved the issue.
