### PR TITLE
HUD now Displays the Correct Item

### DIFF
--- a/src/hud.lua
+++ b/src/hud.lua
@@ -54,7 +54,7 @@ function HUD:draw( player )
     love.graphics.draw( chevron, self.x, self.y)
     love.graphics.setStencil( self.character_stencil, self.x, self.y )
     local currentWeapon = player.inventory:currentWeapon()
-    if currentWeapon and not player.doBasicAttack then
+    if currentWeapon and not player.doBasicAttack and not player.currently_held then
         local position = {x = self.x + 22, y = self.y + 22}
         currentWeapon:draw(position, nil,false)
     else


### PR DESCRIPTION
Adresses #1251
Also makes it so that, of equipped, only projectiles will display in the HUD with number counter.
