### PR TITLE
Partial fix to tavern floorspace bug

### DIFF
--- a/src/nodes/floorspace.lua
+++ b/src/nodes/floorspace.lua
@@ -263,7 +263,7 @@ function Floorspace:collide(node, dt, mtv_x, mtv_y)
         end
     else
         -- primary only
-        if not fp.isBlocked and
+        if self.isPrimary and not fp.isBlocked and
            fp:within( self ) then
             -- keep track of where the player is
             self.lastknown = {


### PR DESCRIPTION
Partial fix to https://github.com/hawkthorne/hawkthorne-journey/issues/957
The "else" statement in [floorspace.lua](https://github.com/hawkthorne/hawkthorne-journey/blob/master/src/nodes/floorspace.lua#L265-L273) marked with the comment "primary only" was still being run in some situations where the node was not primary, such as when fb.isBlocked is false.
By checking for self.isPrimary I found that the player still can get stuck behind the tavern bar, but they can also now easily escape by jumping while holding down.
*Thanks to CalebJohn for the inspiration
