### PR TITLE
Fixes .\make.ps1

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -8,7 +8,7 @@ if($args[0] -eq "clean"){
     return
 }
 
-Write-Host "Running .\make.ps1..."
+Write-Host "Running make.ps1..."
 
 $check = Test-Path -PathType Container bin
 if($check -eq $false){


### PR DESCRIPTION
Makes it so it only extracts if files not found 
Fixed #1331
