### PR TITLE
Generate release notes for Sparkle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ deltas: venv
 	venv/bin/python scripts/upload.py / sparkle/appcast.xml
 
 social: venv post.md notes.html
-	venv/bin/python scripts/upload.py releases/$(current_version) notes.html
+	venv/bin/python scripts/upload_release_notes.py
 	venv/bin/python scripts/socialize.py post.md
 
 notes.html: post.md

--- a/scripts/upload_release_notes.py
+++ b/scripts/upload_release_notes.py
@@ -1,0 +1,20 @@
+import os
+import boto
+import logging
+from boto.s3 import key
+
+import upload
+import version
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+    c = boto.connect_s3()
+    b = c.get_bucket('files.projecthawkthorne.com')
+
+    path = os.path.join('releases', 'v' + version.current_version())
+
+    upload.upload_path(b, path, 'notes.html')
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
All our release notes were being uploading into the wrong directory. No
longer.
