### PR TITLE
Add an empty deselect method. Fixes #1458

### DIFF
--- a/src/nodes/rangedWeapon.lua
+++ b/src/nodes/rangedWeapon.lua
@@ -199,6 +199,11 @@ function Weapon:drop()
     self.player = nil
 end
 
+-- Called when the weapon is returned to the inventory
+-- TODO: What should be done here?
+function Weapon:deselect()
+end
+
 function Weapon:throwProjectile()
     if not self.player then return end
     local ammo = require('items/weapons/'..self.projectile)


### PR DESCRIPTION
@CalebJohn the RangedWeapon class was missing the `deselect` method. I've added an empty function, but I have no idea what it's supposed do. Help?
