### PR TITLE
Check that the door passed into the level exists.

### DIFF
--- a/src/level.lua
+++ b/src/level.lua
@@ -289,7 +289,7 @@ function Level:enter( previous, door, position )
 
     self.hud = HUD.new(self)
 
-    if door then
+    if door and self.doors[door] then
         self.player.position = {
             x = self.doors[ door ].x + self.doors[ door ].node.width / 2 - self.player.width / 2,
             y = self.doors[ door ].y + self.doors[ door ].node.height - self.player.height


### PR DESCRIPTION
Before, we just assumed that a door would exist. If someone had saved in
the old Valley of Laziness, their game save would try to load an invalid
door. We now check that the door is valid before using it.

Fix #1456
