### PR TITLE
Remove 2.5d floorspaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean contributors run forum productionize deploy love
+.PHONY: clean contributors run forum productionize deploy love maps
 
 UNAME := $(shell uname)
 
@@ -16,16 +16,18 @@ else
   wget = wget --no-check-certificate
 endif
 
-maps := $(patsubst %.tmx,%.lua,$(wildcard src/maps/*.tmx))
+tilemaps := $(patsubst %.tmx,%.lua,$(wildcard src/maps/*.tmx))
+
+maps: $(tilemaps)
 
 love: build/hawkthorne.love
 
-build/hawkthorne.love: $(maps) src/*
+build/hawkthorne.love: $(tilemaps) src/*
 	mkdir -p build
 	cd src && zip --symlinks -q -r ../build/hawkthorne.love . -x ".*" \
 		-x ".DS_Store" -x "*/full_soundtrack.ogg" -x "*.bak"
 
-run: $(maps) $(LOVE)
+run: $(tilemaps) $(LOVE)
 	$(LOVE) src
 
 src/maps/%.lua: src/maps/%.tmx bin/tmx2lua
@@ -94,7 +96,7 @@ build/hawkthorne-win-x64.zip: build/hawkthorne.love
 	zip --symlinks -q -r hawkthorne-win-x64 hawkthorne -x "*/love.exe"
 	mv hawkthorne-win-x64.zip build
 
-build/hawkthorne-osx.zip: bin/love.app/Contents/MacOS/love $(maps) src/*
+build/hawkthorne-osx.zip: bin/love.app/Contents/MacOS/love $(tilemaps) src/*
 	mkdir -p build
 	cp -R bin/love.app Journey\ to\ the\ Center\ of\ Hawkthorne.app
 	cp -r src Journey\ to\ the\ Center\ of\ Hawkthorne.app/Contents/Resources/hawkthorne.love

--- a/src/maps/house.tmx
+++ b/src/maps/house.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" width="22" height="14" tilewidth="24" tileheight="24">
+<map version="1.0" orientation="orthogonal" width="22" height="12" tilewidth="24" tileheight="24">
  <properties>
   <property name="jumping" value="false"/>
   <property name="soundtrack" value="tavern"/>
@@ -7,28 +7,28 @@
  <tileset firstgid="1" name="inside" tilewidth="24" tileheight="24">
   <image source="../images/tilesets/inside.png" width="288" height="240"/>
  </tileset>
- <layer name="Background" width="22" height="14">
+ <layer name="Background" width="22" height="12">
   <data encoding="base64" compression="zlib">
-   eJyt0bENgzAQBdBfUDsp6HEfmjCAJ6FAYhGPwigZLT+KT7JOPrCB4svizD19wQBsQ0MmwHueOpxvPQDJg2lxA918XxIy2yW3xeYu3kAcGfZcxv8zOI8/2yl3z555N6f7kPrRjOmUvlFM7Vp27vaG61S0q++t9472at09uwM+V1zL7tS3PeOWdu7oK3nyHzK+pu+rkNWYl1Jyj3Zq/dyt7dPS+25T8gUX5Eq9
+   eJytkUEKgzAQRT/StePCfbNvNnoA6UFcFHqRHMWj9Gh+MIEIZsjELh5DyOTxIALgCWwWZsA5Tg2hV4zuhd6RbzQkw9CLCQiesO3jj/MJqXSvvFvj/RKb6Axxqr2aO/eOjd6+wNWuhZJXcz+AXwe8W70lN72hu9Fbcv+jNzHwD4lLvbnjVcG3cq8Vi38HGO5DQg==
   </data>
  </layer>
- <layer name="Foreground" width="22" height="14">
+ <layer name="Foreground" width="22" height="12">
   <data encoding="base64" compression="zlib">
-   eJyzYWBYYEMDLM/AcIAU9QxEAHkIPgBiU9NcBiRziTWbHHNxmR0IFI+BysnjwITMxQYCgDiQWIeSYC45ZhNrLrLZqQwMDSlADBJzJ9HcJAJmEwLI5vIjiefh0UOM2TBzQWZyEuEOXIADi7mUmonNbJC51DAT3WxqmolsNgBTjkgJ
+   eJyzYWBYwAAENkCamliegeEAqeYyEADyEHwAxqeWuQxo5hJrNjnm4jI7ECgeA5WTx4EJmYsNBABxIDEKSTSXVLNJMRfZ7FQGhoYUIAaJuZNobhIBs/EBfObm4dFHyGxSw4FYQCtzAX80Rd0=
   </data>
  </layer>
- <layer name="Accent" width="22" height="14">
+ <layer name="Accent" width="22" height="12">
   <data encoding="base64" compression="zlib">
-   eJwzZmBYwEBlYAzE9gwMDUC6gcpmggG1zIaZKY8kRqnZyO6UR5Ozp1J4oJtLLTAUzQXiA5SYwUgjc3lpZC42ADTTgYbmNgwlcwGckQ6u
+   eJwzZmBYIM/AkMBAZWDPwNAAoo2hNDWAPJr51DJbHo1PLbPRzYWZTYF5C6CYJmAomgvEB3QpjCtGHOZaAs21AGJzIDYjww5eTHMdQOa6As1yAWJnIHaiTjoDmbuAUnOwmMsAAAVbE74=
   </data>
  </layer>
- <layer name="Overlap" width="22" height="14">
+ <layer name="Overlap" width="22" height="12">
   <data encoding="base64" compression="zlib">
-   eJxjYBgFQwHYD7QDRsEooCKQZ2BYQAsMAJWhEKo=
+   eJxjYBgFQwXYD7QDRsGgBvIMDAuojQEo3Q/r
   </data>
  </layer>
- <objectgroup name="nodes" width="22" height="14">
-  <object type="sprite" x="456" y="144" width="24" height="48">
+ <objectgroup name="nodes" width="22" height="12">
+  <object type="sprite" x="480" y="144" width="24" height="48">
    <properties>
     <property name="animation" value="1-4,1"/>
     <property name="height" value="48"/>
@@ -36,7 +36,7 @@
     <property name="width" value="24"/>
    </properties>
   </object>
-  <object type="sprite" x="48" y="144" width="24" height="48">
+  <object type="sprite" x="72" y="144" width="24" height="48">
    <properties>
     <property name="animation" value="1-4,1"/>
     <property name="flip" value="true"/>
@@ -45,7 +45,7 @@
     <property name="width" value="24"/>
    </properties>
   </object>
-  <object type="hiddendoortrigger" x="191" y="172" width="67" height="43">
+  <object type="hiddendoortrigger" x="215" y="172" width="67" height="43">
    <properties>
     <property name="height" value="66"/>
     <property name="message" value="Straighten masterpiece?"/>
@@ -54,7 +54,7 @@
     <property name="width" value="78"/>
    </properties>
   </object>
-  <object name="fireplace" type="door" x="144" y="192" width="24" height="48">
+  <object name="fireplace" type="door" x="168" y="192" width="24" height="48">
    <properties>
     <property name="aniframes" value="1-2,1"/>
     <property name="animode" value="loop"/>
@@ -70,13 +70,13 @@
     <property name="to" value="main"/>
    </properties>
   </object>
-  <object name="main" type="door" x="383" y="193" width="24" height="48">
+  <object name="main" type="door" x="407" y="193" width="24" height="48">
    <properties>
     <property name="level" value="town"/>
     <property name="to" value="house"/>
    </properties>
   </object>
-  <object type="sprite" x="432" y="241" width="24" height="48">
+  <object type="sprite" x="463" y="195" width="24" height="48">
    <properties>
     <property name="depth" value="-1"/>
     <property name="height" value="48"/>
@@ -84,7 +84,7 @@
     <property name="width" value="24"/>
    </properties>
   </object>
-  <object type="sprite" x="420" y="217" width="24" height="48">
+  <object type="sprite" x="470" y="202" width="24" height="48">
    <properties>
     <property name="depth" value="-1"/>
     <property name="height" value="48"/>
@@ -92,62 +92,15 @@
     <property name="width" value="24"/>
    </properties>
   </object>
-  <object type="sprite" x="84" y="217" width="24" height="48">
-   <properties>
-    <property name="depth" value="-1"/>
-    <property name="height" value="48"/>
-    <property name="sheet" value="images/barrel.png"/>
-    <property name="width" value="24"/>
-   </properties>
-  </object>
-  <object type="sprite" x="24" y="264" width="120" height="48">
-   <properties>
-    <property name="depth" value="24"/>
-    <property name="flip" value="true"/>
-    <property name="height" value="48"/>
-    <property name="sheet" value="images/bed.png"/>
-    <property name="width" value="120"/>
-   </properties>
-  </object>
-  <object type="sprite" x="24" y="240" width="24" height="48">
-   <properties>
-    <property name="flip" value="true"/>
-    <property name="height" value="48"/>
-    <property name="sheet" value="images/bed_headboard.png"/>
-    <property name="width" value="24"/>
-   </properties>
-  </object>
-  <object type="pot" x="452" y="286" width="24" height="24"/>
-  <object type="pot" x="440" y="292" width="24" height="24"/>
-  <object type="pot" x="24" y="293" width="24" height="24"/>
+  <object type="pot" x="312" y="216" width="24" height="24"/>
+  <object type="pot" x="294" y="216" width="24" height="24"/>
  </objectgroup>
- <objectgroup name="floorspace" width="22" height="14">
-  <object x="96" y="240">
-   <properties>
-    <property name="primary" value="true"/>
-   </properties>
-   <polygon points="0,0 336,0 417,82 -82,82"/>
-  </object>
-  <object x="24" y="312">
-   <properties>
-    <property name="height" value="24"/>
-   </properties>
-   <polygon points="0,0 24,-24 120,-24 96,0"/>
-  </object>
-  <object x="432" y="287" width="24" height="3">
-   <properties>
-    <property name="blocks" value="true"/>
-   </properties>
-  </object>
-  <object x="420" y="265" width="24" height="3">
-   <properties>
-    <property name="blocks" value="true"/>
-   </properties>
-  </object>
-  <object x="84" y="265" width="24" height="3">
-   <properties>
-    <property name="blocks" value="true"/>
-   </properties>
-  </object>
+ <objectgroup name="block" width="22" height="12">
+  <object x="0" y="240" width="552" height="48"/>
+  <object x="514" y="0" width="24" height="288"/>
+  <object x="-11" y="-1" width="24" height="288"/>
+  <object x="27" y="219" width="91" height="24"/>
+  <object x="27" y="206" width="20" height="18"/>
  </objectgroup>
+ <objectgroup name="platform" width="22" height="12"/>
 </map>

--- a/src/maps/studyroom.tmx
+++ b/src/maps/studyroom.tmx
@@ -42,6 +42,7 @@
   <object type="sprite" x="58" y="226" width="34" height="70">
    <properties>
     <property name="depth" value="17"/>
+    <property name="foreground" value="true"/>
     <property name="height" value="70"/>
     <property name="sheet" value="images/plant.png"/>
     <property name="width" value="34"/>
@@ -72,51 +73,18 @@
     <property name="width" value="120"/>
    </properties>
   </object>
-  <object name="bookshelf" type="savepoint" x="540" y="220" width="24" height="48"/>
- </objectgroup>
- <objectgroup name="floorspace" width="29" height="14">
-  <object name="table" x="112" y="275">
-   <properties>
-    <property name="height" value="22"/>
-   </properties>
-   <polygon points="0,0 40,0 10,30 -30,30"/>
-  </object>
-  <object name="bookshelf" x="600" y="264">
-   <properties>
-    <property name="height" value="93"/>
-   </properties>
-   <polygon points="-7,-8 13,-8 48,24 24,24"/>
-  </object>
-  <object x="61" y="279" width="34" height="4">
-   <properties>
-    <property name="blocks" value="true"/>
-   </properties>
-  </object>
-  <object x="214" y="259" width="74" height="7">
-   <properties>
-    <property name="height" value="12"/>
-   </properties>
-  </object>
-  <object x="312" y="260" width="122" height="7">
-   <properties>
-    <property name="height" value="12"/>
-   </properties>
-  </object>
-  <object x="24" y="312">
-   <properties>
-    <property name="primary" value="true"/>
-   </properties>
-   <polygon points="0,0 48,-48 600,-48 648,0"/>
-  </object>
-  <object x="536" y="260" width="33" height="10">
-   <properties>
-    <property name="height" value="48"/>
-   </properties>
-  </object>
+  <object name="bookshelf" type="savepoint" x="552" y="216" width="24" height="48"/>
  </objectgroup>
  <layer name="celebrate" width="29" height="14">
   <data encoding="base64" compression="zlib">
    eJxjYBgFo4B2IJKBYYEzkHYBYlcgdgNidyD2AGJPIPYC4igGBgVq2+kHpP2BOACIA4E4CIiDgTgEiEPR7DQEYiMK7fSB2IsXA9U0wNTbALEthXaOAvqAMCAOR+IbA7EdENvTwW5jaJpBdoM3HeylFAAAAV8Paw==
   </data>
  </layer>
+ <objectgroup name="block" width="29" height="14">
+  <object x="72" y="264" width="552" height="48"/>
+  <object x="602" y="173" width="39" height="109"/>
+  <object x="624" y="0" width="48" height="312"/>
+  <object x="24" y="0" width="48" height="312"/>
+  <object x="107" y="253" width="49" height="21"/>
+ </objectgroup>
 </map>

--- a/src/maps/tavern.tmx
+++ b/src/maps/tavern.tmx
@@ -1,52 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" width="22" height="14" tilewidth="24" tileheight="24">
+<map version="1.0" orientation="orthogonal" width="22" height="12" tilewidth="24" tileheight="24">
  <properties>
   <property name="soundtrack" value="tavern"/>
  </properties>
  <tileset firstgid="1" name="inside" tilewidth="24" tileheight="24">
   <image source="../images/tilesets/inside.png" width="288" height="240"/>
  </tileset>
- <layer name="background" width="22" height="14">
+ <layer name="background" width="22" height="12">
   <data encoding="base64" compression="zlib">
-   eJy90L0NgCAYRdFXWRk1hsLSHhscgFkYhVEdRRRICPJjAC1u3kdzCjiAXcUAuQKHSRSsYNqSXDWom9fbD9Pm2pv2hb+Xo274GzNdm2hDhpZoC6GNmbaxsJQZcnuznfeudW2z2aWx2+Ifph/+t4VL88lEpWbOvSswX7n0I9PuCRYfUsk=
+   eJyzY2BgMAJiQwaGBgUGhgdQnEAGnWAIMavBDoj5gGw7ys3GMBOGkc3WgZifgE6DzAGyGdBpXGYimy0CMaMBGy0CMYsBG43LTBjmJxPjMxObuTxQmg2NT6m5MCwEpSWobC41wkGADuFLrrnapOEGPJhUs4g1F8VsAA0BQsE=
   </data>
  </layer>
- <layer name="foreground" width="22" height="14">
+ <layer name="foreground" width="22" height="12">
   <data encoding="base64" compression="zlib">
-   eJwzZmBoYKAyMAZie6C5QHoBlc0EAyC9gBpmI5sJA5Sajc1MZLMLgXQRGebiMhMGgOY6AM11QBZjhdLsZNiHZC6GewWBWA6IhbGoLwDGez4RaSoFiFOR+CpArAXFMD4yALrhANAtB4hwMkkAaG5DIQ3yADGAgwJ7OWhgJi6zqWEmutnUNBPZbADpIxWS
+   eJwzZmBoYKAyMAZie6C5QHoBlc1kkGdgOACkF1DDbCQzweYyQPgUmQ0zkwHNXJjZhUC6iAxz7ZHY6OaCANBcB6C5DshirFCanUg7cJiL4V5BIJYDYmEsZhQA4z0fLU0hm+sOFUsB4lQkNSpArAXFMD4yALrhQCGa25DNZcTmISIA0NyGQjzu5SXTXGwAW/hS0dwFtMAAGbQs/w==
   </data>
  </layer>
- <layer name="accents" width="22" height="14">
+ <layer name="accents" width="22" height="12">
   <data encoding="base64" compression="zlib">
-   eJxjYBgF9ATyDAwNZOgZVObKIWisdlLqXi0amYtHD9XMVSTRXFqD5IF2AAN93QAAIUUGwg==
+   eJxjYKANkGdgOEADM4c8APqhgQw9g8pcOQSN1U5K3atFI3Px6KGauYokmksMSCZCDa3yGwCsPghb
   </data>
  </layer>
- <layer name="top" width="22" height="14">
+ <layer name="top" width="22" height="12">
   <data encoding="base64" compression="zlib">
-   eJxjYBgF9ATyDAwJ5OCBdvdgB2UMDA20MDeDFoYCQTqNzC2mkblDBQAAUdoJKw==
+   eJxjYBgF9ATyDAwJ5OCBdvcoGJkAAOsrBvM=
   </data>
  </layer>
- <objectgroup name="floorspace" width="22" height="14">
-  <object x="363" y="266" width="62" height="15">
-   <properties>
-    <property name="height" value="15"/>
-   </properties>
-  </object>
-  <object x="170" y="247">
-   <properties>
-    <property name="height" value="38"/>
-   </properties>
-   <polygon points="0,0 165,0 165,-3 20,-3 20,-25 0,-25"/>
-  </object>
-  <object x="0" y="336">
-   <properties>
-    <property name="primary" value="true"/>
-   </properties>
-   <polygon points="0,0 96,-96 432,-96 528,0"/>
-  </object>
- </objectgroup>
- <objectgroup name="nodes" width="22" height="14">
-  <object type="sprite" x="447" y="144" width="24" height="48">
+ <objectgroup color="#3059bb" name="nodes" width="22" height="12">
+  <object type="sprite" x="456" y="120" width="24" height="48">
    <properties>
     <property name="animation" value="1-4,1"/>
     <property name="height" value="48"/>
@@ -54,7 +35,7 @@
     <property name="width" value="24"/>
    </properties>
   </object>
-  <object type="sprite" x="168" y="168" width="168" height="79">
+  <object type="sprite" x="168" y="161" width="168" height="79">
    <properties>
     <property name="animation" value="1-5,1"/>
     <property name="depth" value="3"/>
@@ -64,7 +45,7 @@
     <property name="width" value="168"/>
    </properties>
   </object>
-  <object type="sprite" x="359" y="212" width="72" height="72">
+  <object type="sprite" x="397" y="181" width="72" height="72">
    <properties>
     <property name="animation" value="1-8,1|1-7,2"/>
     <property name="depth" value="16"/>
@@ -73,19 +54,18 @@
     <property name="width" value="72"/>
    </properties>
   </object>
-  <object name="main" type="door" x="49" y="230" width="17" height="53">
+  <object name="main" type="door" x="48" y="192" width="24" height="48">
    <properties>
-    <property name="button" value="LEFT"/>
     <property name="level" value="town"/>
     <property name="to" value="tavern"/>
    </properties>
   </object>
-  <object type="pot" x="94" y="220" width="24" height="24"/>
-  <object type="pot" x="140" y="219" width="24" height="24"/>
-  <object type="dealer" x="356" y="225" width="78" height="27"/>
-  <object type="pot" x="107" y="229" width="24" height="24"/>
-  <object type="pot" x="127" y="226" width="24" height="24"/>
-  <object type="sprite" x="168" y="168" width="24" height="79">
+  <object type="pot" x="96" y="216" width="24" height="24"/>
+  <object type="pot" x="107" y="216" width="24" height="24"/>
+  <object type="dealer" x="397" y="205" width="78" height="27"/>
+  <object type="pot" x="120" y="216" width="24" height="24"/>
+  <object type="pot" x="131" y="217" width="24" height="24"/>
+  <object type="sprite" x="168" y="161" width="24" height="79">
    <properties>
     <property name="depth" value="50"/>
     <property name="height" value="79"/>
@@ -93,5 +73,14 @@
     <property name="width" value="24"/>
    </properties>
   </object>
+ </objectgroup>
+ <objectgroup name="block" width="22" height="12">
+  <object x="0" y="240" width="528" height="48"/>
+  <object x="504" y="0" width="24" height="240"/>
+  <object x="0" y="0" width="24" height="240"/>
+  <object x="398" y="217" width="72" height="25"/>
+ </objectgroup>
+ <objectgroup color="#a400a1" name="platform" width="22" height="12">
+  <object x="168" y="203" width="167" height="37"/>
  </objectgroup>
 </map>


### PR DESCRIPTION
This is going to be a very controversial change, so I only did it to three levels. My reasoning for removing the floorspaces is as follows:
1. With floorspaces removed, we can finally ditch the interact button and just use UP
2. Movement on floorspaces feels different than the rest of the game.
3. The floorspace code is complicated (and large). Editing floorspace levels is also complicated, because you have to move the bottoms of items around.
4. Removing floorspaces means all levels play exactly the same. No change of controls. Doors are always up.

This is what the three levels look like. They function almost exactly the same.

![untitled 2](https://f.cloud.github.com/assets/34893/558732/79b18a2e-c42d-11e2-9590-e1bd7f966501.png)
![untitled](https://f.cloud.github.com/assets/34893/558734/7ba165a2-c42d-11e2-9162-c222679cd9f5.png)
![untitled 3](https://f.cloud.github.com/assets/34893/558730/4323c666-c42d-11e2-89a3-b03079835409.png)

Also, removing floorspaces breaks some things. Pots no longer work.
