### PR TITLE
Test TMX file generation on pull requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ bin/love.app/Contents/MacOS/love:
 # THE REST OF THESE TARGETS ARE FOR RELEASE AUTOMATION
 ######################################################
 
-CI_TARGET=test validate
+CI_TARGET=test validate maps
 
 ifeq ($(TRAVIS), true)
 ifeq ($(TRAVIS_BRANCH), release)


### PR DESCRIPTION
To prevent improper TMX files from making it into master, we run them all through tmx2lua to make sure they are valid.
