### PR TITLE
Pokergame Dealing Fix

### DIFF
--- a/src/pokergame.lua
+++ b/src/pokergame.lua
@@ -244,16 +244,10 @@ function state:deal_hand()
     end
 
     -- deal first 5 cards
-    self:deal_card( 'player' )
-    self:deal_card( 'dealer' )
-    self:deal_card( 'player' )
-    self:deal_card( 'dealer' )
-    self:deal_card( 'player' )
-    self:deal_card( 'dealer' )
-    self:deal_card( 'player' )
-    self:deal_card( 'dealer' )
-    self:deal_card( 'player' )
-    self:deal_card( 'dealer' )
+    for i=1, 5 do
+        self:deal_card( 'player' )
+        self:deal_card( 'dealer' )
+    end
 
 end
 
@@ -261,6 +255,7 @@ end
 function state:quit()
     self.prompt = Prompt.new("Are you sure you want to exit?", function(result)
         if result == 'Yes' then
+            self.card_complete_callback = nil
             Gamestate.switch(self.previous)
         else
             self.prompt = nil


### PR DESCRIPTION
If you quit out of the poker game while dealing, it switches to the draw option when you try to play again, this removes the function that causes this on quit.

to test:
1. open pokergame
2. press deal
3. quit while dealing
4. replay, after a couple of seconds the options change

this just resets the callback so this doesn't happen, another option is to remove the quit option while dealing, let me know which is better.
