### PR TITLE
Fixes Instant doors on the edge of levels

### DIFF
--- a/src/nodes/door.lua
+++ b/src/nodes/door.lua
@@ -115,14 +115,6 @@ function Door:collide(node)
     end
 end
 
-function Door:enter(previous)
-    self.loaded = os.time()
-end
-
-function Door:leave()
-    self.loaded = nil
-end
-
 function Door:keypressed( button, player)
     if player.freeze or player.dead then return end
     if self.hideable and self.hidden then return end


### PR DESCRIPTION
fixes #1498
This removes all references to instant_block which seemed like a device to prevent re-entering doors within a second of entering a level, it doesn't seem like this is necessary so I removed it, if it does cause bugs then i can just reset the instant_block variable on collision to fix the bug.
