### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,12 @@ positions: $(patsubst %.png,%.lua,$(wildcard src/positions/*.png))
 src/positions/%.lua: psds/positions/%.png
 	overlay2lua src/positions/config.json $<
 
-build/hawkthorne-win-x86.zip: build/hawkthorne.love
+win32/love.exe: # Should be renamed, as the zip includes both win32 and win64
+	$(wget) https://bitbucket.org/kyleconroy/love/downloads/windows-build-files.zip
+	unzip -q windows-build-files.zip
+	rm -f windows-build-files.zip
+
+build/hawkthorne-win-x86.zip: build/hawkthorne.love win32/love.exe
 	mkdir -p build
 	rm -rf hawkthorne
 	rm -f hawkthorne-win-x86.zip
@@ -82,12 +87,7 @@ build/hawkthorne-win-x86.zip: build/hawkthorne.love
 	zip --symlinks -q -r hawkthorne-win-x86 hawkthorne -x "*/love.exe"
 	mv hawkthorne-win-x86.zip build
 
-win32/love.exe:
-	$(wget) https://bitbucket.org/kyleconroy/love/downloads/windows-build-files.zip
-	unzip -q windows-build-files.zip
-	rm -f windows-build-files.zip
-
-build/hawkthorne-win-x64.zip: build/hawkthorne.love
+build/hawkthorne-win-x64.zip: build/hawkthorne.love win32/love.exe
 	mkdir -p build
 	rm -rf hawkthorne
 	rm -f hawkthorne-win-x64.zip


### PR DESCRIPTION
Changing Windows build targets to include downloading the love files for Windows

Moving the win32/love.exe block to before the hawkthorne-win blocks, and adding win32/love.exe as a prerequisite for building those targets.

I'm not sure if this is as clean as simply calling `make win32/love.exe` before any Windows targets, so discussion is needed.
