### PR TITLE
change jumpdamage to 4 from 3

### DIFF
--- a/src/player.lua
+++ b/src/player.lua
@@ -73,7 +73,7 @@ function Player.new(collider)
     plyr.max_health = 20
     plyr.health = plyr.max_health
     
-    plyr.jumpDamage = 4
+    plyr.jumpDamage = 3
     plyr.punchDamage = 1
 
     plyr.inventory = Inventory.new( plyr )


### PR DESCRIPTION
I thought that in our current state, the player is way too powerful, so I nerfed the jumpdamage so that it's 3, instead of 4. The hippies in the hallway are still killable with two jumps, as their HP is 6.
