### PR TITLE
Remove bookshelf from Studyroom

### DIFF
--- a/src/maps/studyroom.tmx
+++ b/src/maps/studyroom.tmx
@@ -96,7 +96,7 @@
     <property name="height" value="12"/>
    </properties>
   </object>
-  <object type="floorspace" x="24" y="312">
+  <object x="24" y="312">
    <properties>
     <property name="primary" value="true"/>
    </properties>


### PR DESCRIPTION
The bookshelf in the study room was causing problems so I removed the floorspace aspect of it.

The big problem was colliding with floorspaces from the side while jumping.

and if your wondering how to explain why you can't stand on it anymore, it's because we needed to make it taller to fit more books on it.
