### PR TITLE
Fix Font Problems

### DIFF
--- a/src/hud.lua
+++ b/src/hud.lua
@@ -66,14 +66,11 @@ function HUD:draw( player )
     else
         love.graphics.drawq( self.sheet, self.character_quad, self.x + 7, self.y + 17 )
     end
-    
-    fonts.set( 'small' )
-    
     love.graphics.setStencil( )
     love.graphics.draw( lens, self.x, self.y)
     love.graphics.setColor( 0, 0, 0, 255 )
-    love.graphics.print( player.money, self.x + 69, self.y + 41)
-    love.graphics.printf( player.character:current().name, self.x + 55, self.y + 15, 50, 'center' )
+    love.graphics.print( player.money, self.x + 69, self.y + 41,0,0.5,0.5)
+    love.graphics.print( player.character:current().name, self.x + 60, self.y + 15,0,0.5,0.5)
     love.graphics.setColor( 255, 255, 255, 255 )
 
     fonts.revert()


### PR DESCRIPTION
Because of the end font.revert() and internal double font set in hud.la all fonts in the game were set to 'big'
Ideally the love allign would include a scale option... but it doesn't.
So unfortunately we're going to have to drop small aesthetics to keep the game consistent.

Oh and the problem areas:
debug and shopping fonts
