### PR TITLE
Returns liquid default to foreground

### DIFF
--- a/src/nodes/liquid.lua
+++ b/src/nodes/liquid.lua
@@ -58,7 +58,7 @@ function Liquid.new(node, collider)
     liquid.injure = np.injure == 'true'
     liquid.drown = np.drown == 'true'
     liquid.drag = np.drag == 'true'
-    liquid.foreground = np.foreground == 'false'
+    liquid.foreground = np.foreground ~= 'false'
     liquid.mask = np.mask == 'true'
     liquid.uniform = np.uniform == 'true'
     liquid.opacity = np.opacity and np.opacity or 1


### PR DESCRIPTION
This fixes the tokens sitting in front of liquid, I couldn't find the bug report for it

It looks like the foreground default was changed in [this commit](https://github.com/hawkthorne/hawkthorne-journey/commit/5fc539f65d059a1a83b25ff28f16a240f6b4b42a) 

This pull just reverts that change to restore the default to true.

I call upon @didory123 to give a little context to the original change, so that we can approve or deny this pull.
