### PR TITLE
Prevents attacking while crawling

### DIFF
--- a/src/player.lua
+++ b/src/player.lua
@@ -291,6 +291,10 @@ function Player:keypressed( button, map )
     elseif button == 'RIGHT' or button == 'LEFT' then
         if self.current_state_set ~= 'crawling' and controls.isDown( 'DOWN' )
            and not self.currentLevel.floorspace then
+            --dequips
+            if self.currently_held and self.currently_held.isWeapon then
+                self.currently_held:deselect()
+            end
             self:setSpriteStates( 'crawling' )
         end
     end


### PR DESCRIPTION
fixes #1726

With this pull I'm contemplating adjusting the way we handle player states, this is the same issue that happened with attacking while climbing ropes.
