### PR TITLE
Stand up after crawl collision

### DIFF
--- a/src/player.lua
+++ b/src/player.lua
@@ -329,7 +329,7 @@ function Player:checkBlockedCrawl ()
         if block:collidesWith(self.bottom_bb) and block.node.isSolid then
             for _, shape in ipairs(self.collider:shapesAt(top_bb_x,top_bb_y)) do
                 if shape:collidesWith(self.top_bb) and shape.node.isSolid then
-                    Timer.add(0.8, function() self:checkBlockedCrawl() end)
+                    Timer.add(0.4, function() self:checkBlockedCrawl() end)
                     self:setSpriteStates('crawling')
                     return
                 end


### PR DESCRIPTION
This does a repeated check while crawling so that the player will stand up automatically after leaving the "tunnel".

I chose it to do the check every 0.8 seconds because this felt like a good time where it's not super inefficient but it also didn't feel to bad with the delay. 
