### PR TITLE
Remove healthtext

### DIFF
--- a/src/player.lua
+++ b/src/player.lua
@@ -577,7 +577,6 @@ end
 -- @param damage The amount of damage to deal to the player
 --
 function Player:hurt(damage)
-
     if self.invulnerable or self.godmode then
         return
     end


### PR DESCRIPTION
Fixes #1815.

Now when hit, the damage taken by the player flashes instead of that weird -1 image. It doesn't look as good as the image font though, but I guess this does it functionally.  
