### PR TITLE
Add ability to mark gamestates as paused. Fix #1825

### DIFF
--- a/src/level.lua
+++ b/src/level.lua
@@ -608,8 +608,7 @@ function Level:keypressed( button )
     end
 
     if button == 'START' and not self.player.dead and self.player.health > 0 and not self.player.controlState:is('ignorePause') then
-      self.paused = true
-      Gamestate.switch('pause', self.player)
+      Gamestate.stack('pause', self.player)
       return true
     end
 end

--- a/src/nodes/activenpcs/blacksmith.lua
+++ b/src/nodes/activenpcs/blacksmith.lua
@@ -43,7 +43,7 @@ return {
             player.freeze = false
             local screenshot = love.graphics.newImage( love.graphics.newScreenshot() )
             if result == "Yes" then
-                Gamestate.switch("shopping", player, screenshot, activenpc.name)
+                Gamestate.stack("shopping", player, screenshot, activenpc.name)
             end
         end
         player.freeze = true

--- a/src/nodes/cauldron.lua
+++ b/src/nodes/cauldron.lua
@@ -61,7 +61,7 @@ function Cauldron:keypressed( button, player )
             player.freeze = false
             if result == 'Yes' then
                 local screenshot = love.graphics.newImage(love.graphics.newScreenshot())
-                Gamestate.switch('brewing', player, screenshot)
+                Gamestate.stack('brewing', player, screenshot)
             end
         end
         self.prompt = Prompt.new(message, callback, options)

--- a/src/nodes/dealer.lua
+++ b/src/nodes/dealer.lua
@@ -47,7 +47,7 @@ function Dealer:keypressed( button, player )
             player.freeze = false
             if result == 'Poker' or result == 'Blackjack' then
               local screenshot = love.graphics.newImage( love.graphics.newScreenshot() )
-              Gamestate.switch(result:lower() .. 'game', player, screenshot)
+              Gamestate.stack(result:lower() .. 'game', player, screenshot)
             end
         end
 

--- a/src/vendor/gamestate.lua
+++ b/src/vendor/gamestate.lua
@@ -80,6 +80,13 @@ function GS.switch(to, ...)
   return current:enter(pre, ...)
 end
 
+-- Same as GS.switch, but mark the current gamestate as paused
+function GS.stack(to, ...)
+  current.paused = true
+  return GS.switch(to, ...)
+end
+
+
 -- holds all defined love callbacks after GS.registerEvents is called
 -- returns empty function on undefined callback
 local registry = setmetatable({}, {__index = function() return __NULL__ end})


### PR DESCRIPTION
Instead of having to pass around the level, we add a new method `stack`
that marks the current gamestate as paused. This will have no effect on
non-level gamestates. Nodes also don't have to have a reference to the
level to make this work.
