### PR TITLE
Reduce player's health

### DIFF
--- a/src/hud.lua
+++ b/src/hud.lua
@@ -57,7 +57,7 @@ function HUD:draw( player )
         0,
         255
     )
-    love.graphics.draw( energy, self.x - ( player.max_health - player.health ) * 2.8, self.y )
+    love.graphics.draw( energy, self.x - ( player.max_health - player.health ) * 5.6, self.y )
     love.graphics.setStencil( self.character_stencil, self.x, self.y )
     love.graphics.setColor( 255, 255, 255, 255 )
     local currentWeapon = player.inventory:currentWeapon()

--- a/src/player.lua
+++ b/src/player.lua
@@ -18,8 +18,8 @@ local Inventory = require('inventory')
 
 local healthbarq = {}
 
-for i=20,0,-1 do
-    table.insert(healthbarq, love.graphics.newQuad(28 * i, 0, 28, 27,
+for i=10,0,-1 do
+    table.insert(healthbarq, love.graphics.newQuad(28 * i * 2, 0, 28, 27,
                              healthbar:getWidth(), healthbar:getHeight()))
 end
 
@@ -69,7 +69,7 @@ function Player.new(collider)
     --for damage text
     plyr.healthText = {x=0, y=0}
     plyr.healthVel = {x=0, y=0}
-    plyr.max_health = 20
+    plyr.max_health = 10
     plyr.health = plyr.max_health
     
     plyr.jumpDamage = 3


### PR DESCRIPTION
This reduces player's health from 20 to 10, which is still higher than I think it should be, but this works nicely with the images we have for the pop-up health bar. This follows from discussion in #1473.
