### PR TITLE
Nerf the Turkey Boss

### DIFF
--- a/src/maps/black-caverns-2.tmx
+++ b/src/maps/black-caverns-2.tmx
@@ -683,7 +683,7 @@
     <property name="nodeType" value="enemy"/>
     <property name="spawnMax" value="5"/>
     <property name="spawnType" value="proximity"/>
-    <property name="velocityX" value="-200"/>
+    <property name="velocityX" value="-50"/>
    </properties>
   </object>
   <object type="spawn" x="2092" y="350" width="67" height="67">
@@ -830,7 +830,7 @@
    <properties>
     <property name="enemytype" value="turkey"/>
     <property name="nodeType" value="enemy"/>
-    <property name="spawnMax" value="15"/>
+    <property name="spawnMax" value="0"/>
     <property name="spawnType" value="proximity"/>
     <property name="velocityX" value="50"/>
    </properties>
@@ -839,7 +839,7 @@
    <properties>
     <property name="enemytype" value="turkey"/>
     <property name="nodeType" value="enemy"/>
-    <property name="spawnMax" value="15"/>
+    <property name="spawnMax" value="0"/>
     <property name="spawnType" value="proximity"/>
     <property name="velocityX" value="-50"/>
    </properties>

--- a/src/nodes/enemies/turkeyBoss.lua
+++ b/src/nodes/enemies/turkeyBoss.lua
@@ -25,7 +25,7 @@ return {
     attack_width = 40,
     attack_offset = { x = -40, y = 10},
     velocity = {x = 0, y = 1},
-    hp = 200,
+    hp = 100,
     tokens = 15,
     hand_x = -40,
     hand_y = 70,
@@ -115,7 +115,7 @@ return {
             love.graphics.rectangle( 'fill', x + 11, y + 27, 59, 9 )
         end
         love.graphics.setStencil(energy_stencil, x, y)
-        local max_hp = 200
+        local max_hp = 100
         local rate = 55/max_hp
         love.graphics.setColor(
             math.min(utils.map(enemy.hp, max_hp, max_hp / 2 + 1, 0, 255 ), 255), -- green to yellow
@@ -220,9 +220,10 @@ return {
             Timer.add(0.75, function() enemy.direction = direction == -1 and 'right' or 'left' end)
             
         elseif enemy.last_attack > pause and enemy.state ~= 'jump' then
-            if math.random() > 0.9 and enemy.hp < 80 then
+            local rand = math.random()
+            if enemy.hp < 80 and rand > 0.9 then
                 enemy.props.spawn_minion(enemy, direction)
-            elseif math.random() > 0.6 then
+            elseif rand > 0.6 then
                 enemy.props.wing_attack(enemy, player, enemy.props.attackDelay)
             else
                 enemy.props.attackBasketball(enemy)


### PR DESCRIPTION
Closes #1828
Reduces the Turkey Boss's health from 200 to 100.
Turns off turkey spawns in the boss arena.
Changes the attack selection to only call math.random() once.
