### PR TITLE
Accept new command line arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,9 @@ bin/tmx2lua:
 
 bin/love.app/Contents/MacOS/love:
 	mkdir -p bin
-	$(wget) https://bitbucket.org/kyleconroy/love/downloads/love-osx-mavericks-fixed.zip
-	unzip -q love-osx-mavericks-fixed.zip
-	rm -f love-osx-mavericks-fixed.zip
+	$(wget) https://bitbucket.org/rude/love/downloads/love-0.8.0-macosx-ub.zip
+	unzip -q love-0.8.0-macosx-ub.zip
+	rm -f love-0.8.0-macosx-ub.zip
 	mv love.app bin
 	cp osx/Info.plist bin/love.app/Contents
 

--- a/osx/Info.plist
+++ b/osx/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>BuildMachineOSBuild</key>
-	<string>12C54</string>
+	<string>12D78</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleExecutable</key>
@@ -18,6 +18,8 @@
 	<string>Journey to the Center of Hawkthorne</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.8.0</string>
 	<key>CFBundleSignature</key>
 	<string>HaWk</string>
 	<key>CFBundleVersion</key>
@@ -25,19 +27,21 @@
 	<key>DTCompiler</key>
 	<string></string>
 	<key>DTPlatformBuild</key>
-	<string>4G1004</string>
+	<string>4H512</string>
 	<key>DTPlatformVersion</key>
 	<string>GM</string>
 	<key>DTSDKBuild</key>
-	<string>12C37</string>
+	<string>12D75</string>
 	<key>DTSDKName</key>
 	<string>macosx10.8</string>
 	<key>DTXcode</key>
-	<string>0451</string>
+	<string>0461</string>
 	<key>DTXcodeBuild</key>
-	<string>4G1004</string>
+	<string>4H512</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>2006-2012 Hawkthorne Development Team</string>
+	<string>© 2006-2012 Hawkthorne Development Team</string>
+	<key>NSMainNibFile</key>
+	<string>SDLMain</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 </dict>

--- a/src/main.lua
+++ b/src/main.lua
@@ -45,6 +45,8 @@ function love.load(arg)
   -- The Mavericks builds of Love adds too many arguements
   arg = utils.cleanarg(arg)
 
+  local mixpanel = require 'vendor/mixpanel'
+
   local state, door, position = 'update', nil, nil
 
   -- SCIENCE!
@@ -56,6 +58,7 @@ function love.load(arg)
   options:init()
 
   cli:add_option("--console", "Displays print info")
+  cli:add_option("--fused", "Passed in when the app is running in fused mode")
   cli:add_option("-b, --bbox", "Draw all bounding boxes ( enables memory debugger )")
   cli:add_option("-c, --character=NAME", "The character to use in the game")
   cli:add_option("-d, --debug", "Enable Memory Debugger")
@@ -73,8 +76,7 @@ function love.load(arg)
   local args = cli:parse(arg)
 
   if not args then
-    love.event.push("quit")
-    return
+    error("Could not parse command line arguments")
   end
 
   if args["test"] then


### PR DESCRIPTION
The new version of love we're using for OS X passes the `--fused` command line argument when in fused mode. We now 1) error instead of quitting when the arguments are broken and 2) accept that flag. This also uses the main download link, as that is the one that's been updated.
