### PR TITLE
Sets proper size when dropping items

### DIFF
--- a/src/inventory.lua
+++ b/src/inventory.lua
@@ -445,9 +445,6 @@ function Inventory:drop()
         
         local height = item.image:getHeight() - 15
 
-        itemProps.width = item.image:getWidth()
-        itemProps.height = item.image:getHeight() - 15
-
         itemProps.width = itemProps.width or item.image:getWidth()
         itemProps.height = itemProps.height or height
 


### PR DESCRIPTION
It looks like there was a bad git merge sometime back and a couple of lines were left in inventory.lua, I removed the two older ones because they did nothing.
