### PR TITLE
Prevents Player dropping on moving platforms (After Pause)

### DIFF
--- a/src/level.lua
+++ b/src/level.lua
@@ -394,7 +394,9 @@ function Level:update(dt)
     end
 
     for i,node in pairs(self.nodes) do
-        if node.update then node:update(dt, self.player) end
+        if self.state == 'active' and node.update then
+            node:update(dt, self.player)
+        end
     end
 
     self.collider:update(dt)


### PR DESCRIPTION
fixes #1512

The issue was caused by the level preventing player movement while it fades in but allowing nodes to update.

This pull prevents nodes from updating while the level is fading in, which I think may have been the original intention but got left out?

This may look weird for liquids and sparkles and such, so depending on the reception, this pull can updated to flag nodes that should not update during level fade.
