### PR TITLE
Ensures that a weapon is still drawn once dropped in a floorspace

### DIFF
--- a/src/level.lua
+++ b/src/level.lua
@@ -537,8 +537,8 @@ function Level:floorspaceNodeDraw()
                     self.player:draw()
                     player_drawn = true
                 end
-                -- weapon:draw() is managed in player.lua to hack it with the floorspace
-                if not node.isWeapon then
+                -- weapon:draw() is managed in player.lua while the player is holding it
+                if not (node.isWeapon and node.player) then
                     node:draw()
                 end
             end


### PR DESCRIPTION
When #1655 was merged in it stopped level.lua from drawing weapons that weren't in the players inventory. This caused an issue where weapons that are dropped are no longer visible.

This only prevents the level.lua from drawing weapons that will be managed by the player.

With this pull you should be able to see dropped weapons in 2.5D and they should draw correctly in relation to the player when walking back.
