### PR TITLE
Fix missing key message

### DIFF
--- a/src/nodes/door.lua
+++ b/src/nodes/door.lua
@@ -97,7 +97,12 @@ function Door:switch(player)
     else
         sound.playSfx('locked')
         player.freeze = true
-        message = {self.info} or {'You need a "'..self.key..'" key to open this door.'}
+		
+		if self.info then
+			message = {self.info}
+		else
+			message = {'You need a "'..self.key..'" key to open this door.'}
+		end
 
         local callback = function(result)
             self.prompt = nil


### PR DESCRIPTION
Fixes a bug where the game would crash if you tried to enter a locked door without the required key that did not have an info tag. To replicate the bug go straight to the exit of the first black caverns without collecting the key.
