### PR TITLE
Stop the player being hurt when dead

### DIFF
--- a/src/player.lua
+++ b/src/player.lua
@@ -570,7 +570,7 @@ function Player:hurt(damage)
     --Minimum damage is 5%
     --Prevents damage from falling off small heights.
     if damage < 5 then return end
-    if self.invulnerable or self.godmode then
+    if self.invulnerable or self.godmode or self.dead then
         return
     end
 


### PR DESCRIPTION
Currently the player can take damage even though they are already dead, triggering a flash and the noise. The easiest way to test this is in a spike pit.
