### PR TITLE
Removes suicidal acorns from village forest

### DIFF
--- a/src/maps/village-forest-2.tmx
+++ b/src/maps/village-forest-2.tmx
@@ -183,11 +183,6 @@
   <object name="leaf" type="material" x="2256" y="504" width="24" height="24"/>
   <object name="rock" type="material" x="1742" y="815" width="24" height="24"/>
   <object name="rock" type="material" x="456" y="600" width="24" height="24"/>
-  <object type="enemy" x="480" y="696" width="24" height="24">
-   <properties>
-    <property name="enemytype" value="acorn"/>
-   </properties>
-  </object>
   <object type="enemy" x="624" y="696" width="24" height="24">
    <properties>
     <property name="enemytype" value="acorn"/>
@@ -399,11 +394,6 @@
   <object type="enemy" x="696" y="528" width="48" height="48">
    <properties>
     <property name="enemytype" value="fish"/>
-   </properties>
-  </object>
-  <object type="enemy" x="1056" y="648" width="24" height="24">
-   <properties>
-    <property name="enemytype" value="acorn"/>
    </properties>
   </object>
   <object name="rock" type="material" x="2136" y="528" width="24" height="24"/>


### PR DESCRIPTION
There's an acorn which kills itself on the spikes when you enter the level and another which hurts you when you spawn at the save point. These have now been removed.
