### PR TITLE
Bug fix 0.5.1

### DIFF
--- a/src/start.lua
+++ b/src/start.lua
@@ -66,6 +66,8 @@ function state:load_slot( slotNumber )
   end
 
   if point ~= nil and point.level ~= nil then
+    local current = character.current()
+    current.changed = true
     Gamestate.switch(point.level, point.name)
   else
     Gamestate.switch( 'scanning' )


### PR DESCRIPTION
Hi everyone. Hope you all enjoyed the start of Season 5 yesterday!

This release fixes the issues you were all having with loading saved games.

/u/edisonout may have britta'd it missing out two lines of code which meant your inventory wasn't loaded. As an apology, here's a list of cheat codes which may be used to restore your inventory.
- hello rich people (500 coins)
- use respect (gives weapons)
- zombie (gives consumables - taco meat, watermelon & baggle)
- this is more complex (gives materials)
- i want tbd (gives lightning)
- no no juice (gives potions)
- chang level (unlocks all levels)
- greendale is where i belong (greendale key - door will still be hidden until you reach the throne)
- dan harmon (gives master key - again, greendale is still hidden)

We're also aware players can no longer select a character when playing a loaded game. This is part of an on-going process of re-doing the opening to match the episode. In the next major release, you will have the option of changing character and/or costume mid game. If anyone has any suggestions on how we can implement this or what you want it to look like, please comment below. If you can't wait until then, here's a crafty little way to change.
1. save the game
2. go to the folder C:\Users\user\AppData\Roaming\LOVE (replacing 'user' with your PC username) or the mac/linux equivalent
3. find the file 'gamesaves-alpha-1.json' in the release subfolder (or beta or gamma depending on which gameslot you're using)
4. replace "abed" with the name of the character you want to play as
5. replace "base" with the name of the costume (this will be the name of the image, not the name that appears in the game - ask us if you have any problems)
6. restart the game & load the selected slot
