### PR TITLE
Fix Hilda response crash

### DIFF
--- a/src/npcs/hilda.lua
+++ b/src/npcs/hilda.lua
@@ -427,7 +427,7 @@ return {
         "I'm broke.",
         "I tried to buy fertilizer the other day for the soccer field.",
         "Request denied.",
-        "I literally can't buy *bleep*.",
+        "I literally can't buy %$&#!.",
     },
     ['extra large swords']={
         "You have successfully rubbed your balls on his sword.",


### PR DESCRIPTION
fixes #1979
I removed the square brackets in hildas response to 'brick vouchers' and replaced them with asterisks.

The only reason I live this open is in case someone thinks asterisks might be wrong and we should use a separate symbol.
