### PR TITLE
Fix Hilda's stay command

### DIFF
--- a/src/npcs/hilda.lua
+++ b/src/npcs/hilda.lua
@@ -448,7 +448,7 @@ return {
     end,
     ['stay']=function(npc, player)
         npc.walking = false
-        npc.stare = true
+        npc.stare = false
     end,
     ['go home']=function(npc, player)
         npc.walking = true


### PR DESCRIPTION
Since the stare flag is used in the npc module's collide_end function to re-enable walking automatically, telling Hilda to follow and then to stay will have no effect, and she will continue following you.

Setting stare to false fixes the problem although she will no longer automatically face the player when ordered to stay.
