### PR TITLE
Turn off bucket validation to save some cash

### DIFF
--- a/scripts/create_post.py
+++ b/scripts/create_post.py
@@ -29,7 +29,7 @@ def post_content():
 
 
 def commithash(version):
-    bucket = boto.s3.get_bucket("files.projecthawkthorne.com")
+    bucket = boto.s3.get_bucket("files.projecthawkthorne.com", validate=False)
     key = bucket.get_key("releases/v{}/hawkthorne-osx.zip".format(version))
 
     if key is None:

--- a/scripts/s3upload.py
+++ b/scripts/s3upload.py
@@ -10,7 +10,7 @@ parser.add_argument("version", help="Version to upload")
 args = parser.parse_args()
 name = os.path.basename(args.path)
 
-bucket = conn.get_bucket('hawkthorne.journey.builds')
+bucket = conn.get_bucket('hawkthorne.journey.builds', validate=False)
 key = bucket.new_key(os.path.join(args.version, name))
 
 key.set_contents_from_filename(os.path.abspath(args.path))

--- a/scripts/upload.py
+++ b/scripts/upload.py
@@ -28,5 +28,5 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     c = boto.connect_s3()
-    b = c.get_bucket('files.projecthawkthorne.com')
+    b = c.get_bucket('files.projecthawkthorne.com', validate=False)
     upload_path(b, args.prefix, args.path)

--- a/scripts/upload_release_notes.py
+++ b/scripts/upload_release_notes.py
@@ -9,7 +9,7 @@ import version
 def main():
     logging.basicConfig(level=logging.INFO)
     c = boto.connect_s3()
-    b = c.get_bucket('files.projecthawkthorne.com')
+    b = c.get_bucket('files.projecthawkthorne.com', validate=False)
 
     path = os.path.join('releases', 'v' + version.current_version())
 

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -38,7 +38,7 @@ def prev_version():
 
 
 def current_version_tuple():
-    bucket = s3.get_bucket("files.projecthawkthorne.com")
+    bucket = s3.get_bucket("files.projecthawkthorne.com", validate=False)
     key = bucket.get_key("releases/latest/hawkthorne-osx.zip")
     redirect = key.get_redirect()
     _, _, version, _ = redirect.split('/')


### PR DESCRIPTION
Looks like all our helper scripts have been [costing me extra money](http://www.appneta.com/blog/s3-list-get-bucket-default). We don't need to validate because the bucket exists.
