### PR TITLE
Dropping projectiles in floorspace is broken

### DIFF
--- a/src/nodes/projectile.lua
+++ b/src/nodes/projectile.lua
@@ -396,7 +396,16 @@ function Projectile:drop(thrower)
   self.animation = self.defaultAnimation
   thrower.currently_held = nil
   self.holder = nil
+  if thrower.footprint then
+    self:floorspace_drop(thrower)
+    return
+  end
   self.dropped = true
+end
+
+-- handle projectile being dropped in a floorspace
+function Projectile:floorspace_drop(player)
+    self.position.y = player.footprint.y - self.height
 end
 
 return Projectile


### PR DESCRIPTION
Most likely due to my throw dropping items, dropping an item in a floorspace is broken in master. This pull adds a special case for projectiles that gives a slightly different behavior in floorspaces, it looks like this function was already in all the other items so I guess projectiles are just catching up.
