### PR TITLE
Add position to options menu save

### DIFF
--- a/src/level.lua
+++ b/src/level.lua
@@ -404,7 +404,7 @@ function Level:update(dt)
               self.player.money = 0
               self.player.inventory:removeAllItems()
             end
-            Gamestate.switch(point.level, point.name)
+            Gamestate.switch(point.level, point.name, point.position)
         end)
     end
 

--- a/src/options.lua
+++ b/src/options.lua
@@ -181,7 +181,7 @@ function state:save_game()
   if not self.target then return end
   local gamesave = app.gamesaves:active()
   local player = Player.factory()
-  gamesave:set('savepoint', {level=self.target.name})
+  gamesave:set('savepoint',{level=self.target.name, position=player:getPosition()})
   player:saveData(gamesave)
   gamesave:flush()
 end

--- a/src/player.lua
+++ b/src/player.lua
@@ -880,6 +880,15 @@ function Player:cancelHoldable(holdable)
 end
 
 ---
+-- Gets player's relative position in the level
+-- @return position string as "x,y"
+function Player:getPosition()
+  local x = self.position.x / 24
+  local y = self.position.y / 24
+  return x .. "," .. y
+end
+
+---
 -- The player attacks
 -- @return nil
 function Player:attack()


### PR DESCRIPTION
In contrast to Hardcore Mode, this lets the player save at any point within a level and re-spawn at that position when they die. To prevent mid-air positional saving from leading to an endless series of deaths, loading the save slot from the menu will start you at the main entrance to the level.

This should be welcome relief for those players whose limited platforming skills force them to repeat the same obstacles over and over.
