### PR TITLE
Add beeps to options for invalid selection

### DIFF
--- a/src/options.lua
+++ b/src/options.lua
@@ -179,12 +179,12 @@ function state:main_menu()
 end
 
 function state:change_costume()
-  if not self.target then return end
+  if not self.target then sound.playSfx('dbl_beep') return end
   Gamestate.switch('costumeselect', self.target)
 end
 
 function state:save_game()
-  if not self.target then return end
+  if not self.target then sound.playSfx('dbl_beep') return end
   local gamesave = app.gamesaves:active()
   local player = Player.factory()
   gamesave:set('savepoint', {level=self.target.name})


### PR DESCRIPTION
When "Costume" or "Save Game" are selected from the main menu instead of the pause menu, they do nothing. This adds beeps to the doing-nothing-ness so players understand those options aren't currently selectable and doesn't assume they are simply broken.
