### PR TITLE
Offset block in village forest

### DIFF
--- a/src/maps/village-forest-2.tmx
+++ b/src/maps/village-forest-2.tmx
@@ -530,7 +530,7 @@
   <object x="3480" y="768" width="72" height="48"/>
   <object x="3528" y="720" width="24" height="48"/>
   <object x="3528" y="816" width="24" height="24"/>
-  <object x="3600" y="600" width="264" height="168"/>
+  <object x="3600" y="576" width="264" height="168"/>
   <object x="3744" y="504" width="120" height="72"/>
   <object x="3768" y="384" width="96" height="120"/>
   <object x="3648" y="408" width="72" height="48"/>


### PR DESCRIPTION
The last platform jump in village-forest-2 had a block in the wrong position
![screenshot 2014-02-07 19 03 24](https://f.cloud.github.com/assets/2179547/2116021/37f2ad70-9065-11e3-8d75-df82ab994a74.png)

I moved the block up a bit to fix the problem.
