### PR TITLE
Delete individual save slots

### DIFF
--- a/src/start.lua
+++ b/src/start.lua
@@ -123,7 +123,10 @@ function state:keypressed( button )
         self[option.action]()
       end
     elseif button == 'INTERACT' then
-      if love.filesystem.exists('gamesaves-' .. self.saveNames[self.selection] .. '-1.json' ) == true then
+      app.gamesaves:activate( option.slot )
+      local gamesave = app.gamesaves:active()
+      local savepoint = gamesave:get( 'savepoint' )
+      if savepoint ~= nil then
         sound.playSfx('confirm')
         self.window = 'deleteSlot'
       else
@@ -197,6 +200,11 @@ function state:draw()
     end
     love.graphics.draw( self.arrow, 135, 127 + ( (yFactor * arrowYFactor) * ( self.selection - 1 ) ) )
   elseif self.window == 'deleteSlot' then
+    love.graphics.setColor(255, 255, 255)
+    local howto = controls:getKey("UP") .. " OR " .. controls:getKey("DOWN") .. ": CHANGE OPTION"
+    local delete = controls:getKey("JUMP") .. ": SELECT OPTION"
+    love.graphics.print(howto, 25, 25)
+    love.graphics.print(delete, 25, 55)
     love.graphics.setColor( 0, 0, 0, 255 )
     love.graphics.printf('Are you sure you want to delete this slot?', 155, 110, self.background:getWidth() - 30, 'left')
     love.graphics.print('Yes', 175, 175, 0)


### PR DESCRIPTION
Add option to delete save slots one at a time from start menu.

Should probably check to see if files exist before doing anything. Would also like to not have to quit game when deleting stuff.

Look at the first commit if you want to see what I've changed. Second is only to fix spacing.
