### PR TITLE
Adds arrow arc

### DIFF
--- a/src/nodes/projectiles/arrow.lua
+++ b/src/nodes/projectiles/arrow.lua
@@ -8,7 +8,7 @@ return{
   frameWidth = 27,
   frameHeight = 7,
   solid = true,
-  lift = game.gravity,
+  lift = game.gravity * 0.88,
   playerCanPickUp = false,
   enemyCanPickUp = false,
   canPlayerStore = true,
@@ -16,7 +16,7 @@ return{
   throw_sound = 'arrow',
   velocity = { x = -600, y = 0 }, --initial velocity
   throwVelocityX = 600, 
-  throwVelocityY = 0,
+  throwVelocityY = -30,
   stayOnScreen = false,
   thrown = false,
   damage = 2,


### PR DESCRIPTION
fixes #1854

This adds a slight arc to the arrow so that pierce can hit acorns with arrows.

I didn't add much of an arc but everything can be changed (quite easily), Do we want more of an arc? Less of an arc? Faster arrow? Slower?

I set it like this so you could still hit acorns from a reasonable distance, but maybe we want more of an arc to change the entire mechanic of arrows? Make them less overpowered?
