### PR TITLE
Reset fall damage when hitting an enemy

### DIFF
--- a/src/nodes/enemy.lua
+++ b/src/nodes/enemy.lua
@@ -283,6 +283,8 @@ function Enemy:collide(node, dt, mtv_x, mtv_y)
         and player.velocity.y > self.velocity.y and self.jumpkill then
         -- successful attack
         self:hurt(player.jumpDamage)
+        -- reset fall damage when colliding with an enemy
+        player.fall_damage = 0
         player.velocity.y = -450 * player.jumpFactor
     end
 


### PR DESCRIPTION
Title is fairly self explanatory, this is a small change but every time I land on an enemy I'm relieved that I won't take fall damage and then I get hurt anyways which is pretty annoying.

If this is not desired the other option is to have the fall damage effect the player when it hits the enemy rather than when it hits the floor.
