### PR TITLE
Closes Crafting Annex

### DIFF
--- a/src/inventory.lua
+++ b/src/inventory.lua
@@ -101,7 +101,7 @@ function Inventory.new( player )
     inventory.craftingAnimations = {
         opening = anim8.newAnimation('once', craftingGrid('1-6,1'),0.04),
         open = anim8.newAnimation('once', craftingGrid('6,1'), 1),
-        closing = anim8.newAnimation('once', craftingGrid('1-6,1'),0.01)
+        closing = anim8.newAnimation('once', craftingGrid('1-6,1'),0.06)
     }
     inventory.craftingAnimations['closing'].direction = -1
     inventory.craftingAnimations['closing'].position = 6


### PR DESCRIPTION
One thing that has always bothered me about crafting was how the crafting annex window would stay open after crafting something or after removing all materials from the crafting window.  This would prevent you from changing to the menu on the right.  This makes sure that the crafting annex closes when there are no materials in it and when you have successfully crafted an item
