### PR TITLE
Fix for #2118 - player not paralyzed when falling and getting hit

### DIFF
--- a/src/player.lua
+++ b/src/player.lua
@@ -386,7 +386,7 @@ function Player:update( dt )
     end
     
     -- taken from sonic physics http://info.sonicretro.org/SPG:Running
-    if movingLeft and not movingRight and not self.rebounding then
+    if movingLeft and not movingRight then
 
         if crouching and self.crouch_state == 'crouch' and not self.jumping then -- crouch slide
             self.velocity.x = self.velocity.x + (self:accel() * dt)
@@ -410,7 +410,7 @@ function Player:update( dt )
             end
         end
 
-    elseif movingRight and not movingLeft and not self.rebounding then
+    elseif movingRight and not movingLeft then
 
         if crouching and self.crouch_state == 'crouch' and not self.jumping then
             self.velocity.x = self.velocity.x - (self:accel() * dt)


### PR DESCRIPTION
This should fix what I described in issue #2118. Basically, I've enable moving left and right when the player has gotten hurt.
