### PR TITLE
Attack when drawing weapon

### DIFF
--- a/src/hud.lua
+++ b/src/hud.lua
@@ -119,7 +119,7 @@ function HUD:draw( player )
   love.graphics.setColor(255, 255, 255, 255)
 
   local currentWeapon = player.inventory:currentWeapon()
-  if currentWeapon and not player.doBasicAttack and not player.currently_held or (player.holdingAmmo and currentWeapon) then
+  if currentWeapon and not player.doBasicAttack or (player.holdingAmmo and currentWeapon) then
     local position = {x = self.x + 22, y = self.y + 22}
     currentWeapon:draw(position, nil,false)
   else

--- a/src/player.lua
+++ b/src/player.lua
@@ -962,8 +962,17 @@ function Player:attack()
     elseif self.doBasicAttack then
         punch()
     elseif currentWeapon and (currentWeapon.props.subtype=='melee' or currentWeapon.props.subtype == 'ranged') then
-        --take out your weapon
-        currentWeapon:select(self)
+        if self.character.state == "crouch" then
+            -- still allow the player to dig
+            punch()
+        else
+            --take out and use your weapon
+            currentWeapon:select(self)
+            if currentWeapon.props.subtype=='melee' then
+                -- prevent ranged weapons from shooting when drawn
+                self:attack()
+            end
+        end
     elseif currentWeapon then
         --shoot a projectile
         currentWeapon:use(self)


### PR DESCRIPTION
fixes #1863

This pull addresses the concerns that @jhoff brought up, except the hand thing which would actually be cool but we would need to make the sprites. 

I have it set so that even when the weapon is offhand the player can still dig, although attempting to punch will result in the weapon being drawn and used.
