### PR TITLE
Move checkInventory out of NPC update function

### DIFF
--- a/src/inventory.lua
+++ b/src/inventory.lua
@@ -599,6 +599,21 @@ function Inventory:down()
 end
 
 ---
+-- Called when any items are added or removed from the player inventory
+-- @return nil
+function Inventory:change()
+    -- Check player inventory against all NPCs in the current level
+    local level = GS.currentState()
+    if level.nodes then
+        for _,npc in pairs(level.nodes) do
+            if npc.type == 'npc' then
+                npc:checkInventory(self.player)
+            end
+        end
+    end
+end
+
+---
 -- Drops the currently selected item and adds a node at the player's position.
 -- @return nil
 function Inventory:drop()
@@ -648,6 +663,8 @@ function Inventory:drop()
             sound.playSfx('click')
         end
     end
+
+    self:change()
 end
 
 ---
@@ -675,6 +692,9 @@ function Inventory:addItem(item, sfx)
     if sfx ~= false then
         sound.playSfx('pickup')
     end
+
+    self:change()
+
     return true
 end
 
@@ -689,6 +709,8 @@ function Inventory:removeItem( slotIndex, pageName )
         self.player.currently_held:deselect()
     end
     self.pages[pageName][slotIndex] = nil
+
+    self:change()
 end
 
 ---
@@ -698,6 +720,8 @@ function Inventory:removeAllItems()
   for page in pairs(self.pages) do
     self.pages[page] = {}
   end
+
+  self:change()
 end
 ---
 -- Removes a certain amount of items from the player
@@ -718,6 +742,8 @@ function Inventory:removeManyItems(amount, itemToRemove)
             self:removeItem(slotIndex, pageIndex)
         end
     end
+
+    self:change()
 end
 
 ---

--- a/src/nodes/npc.lua
+++ b/src/nodes/npc.lua
@@ -6,6 +6,7 @@ local sound = require 'vendor/TEsound'
 local fonts = require 'fonts'
 local utils = require 'utils'
 local Timer = require 'vendor/timer'
+local Player = require 'player'
 
 local Menu = {}
 Menu.__index = Menu
@@ -241,6 +242,7 @@ function NPC.new(node, collider)
     npc.props = require('npcs/' .. node.name)
 
     npc.name = node.name
+    npc.type = node.type
 
     npc.busy = false
 
@@ -360,6 +362,10 @@ end
 
 function NPC:enter( previous )
     if self.props.enter then self.props.enter(self, previous) end
+
+    -- Check player inventory on NPC creation
+    local player = Player.factory()
+    self:checkInventory(player)
 end
 
 ---
@@ -462,8 +468,6 @@ function NPC:update(dt, player)
             self.direction = "right"
         end
     end
-    
-    self:checkInventory(player)
     
     if self.props.update then
         self.props.update(dt, self, player)


### PR DESCRIPTION
Instead of checking the player inventory on every update, it is more effecient to check only when an item has been added or removed and when the NPC first gets created in the level on the enter function.

This should resolve #2124 and #2114.
