### PR TITLE
Player releases climbable on death

### DIFF
--- a/src/player.lua
+++ b/src/player.lua
@@ -595,6 +595,9 @@ function Player:hurt(damage)
     if self.health <= 0 then
         self.dead = true
         self.character.state = 'dead'
+        if self.isClimbing then
+            self.isClimbing:release(player)
+        end
     else
         self.attacked = true
         self.character.state = 'hurt'


### PR DESCRIPTION
Pretty simple. Player releases any climbable on death. This specifically solves the problem in village-forest-2 with the spikes on the ceiling where the ropes are.

Resolves #2158.
