### PR TITLE
Fix resetting settings/saves issues

### DIFF
--- a/src/options.lua
+++ b/src/options.lua
@@ -71,9 +71,9 @@ local MENU = {
     {name = 'HARDCORE MODE'},
     {name = 'SEND PLAY DATA'},
     {name = 'RESET SETTINGS/SAVES', page = {
-      {name = 'CANCEL RESET'},
       {name = 'RESET SETTINGS'},
       {name = 'RESET SAVES'},
+      {name = 'CANCEL RESET'},
     }},
     {name = 'BACK TO OPTIONS'},
   }},


### PR DESCRIPTION
Fixes #2155 

Can now reset settings and saves separately. It will also send you back to the start menu once you've done so.
