### PR TITLE
Do not offset bounding box if not held by player

### DIFF
--- a/src/nodes/weapon.lua
+++ b/src/nodes/weapon.lua
@@ -177,8 +177,8 @@ function Weapon:collide(node, dt, mtv_x, mtv_y)
 end
 
 function Weapon:initializeBoundingBox(collider)
-    self.boxTopLeft = {x = self.position.x + self.bbox_offset_x[1],
-                        y = self.position.y + self.bbox_offset_y[1]}
+    self.boxTopLeft = {x = self.position.x,
+                        y = self.position.y}
     self.boxWidth = self.bbox_width
     self.boxHeight = self.bbox_height
 

--- a/src/nodes/weapons/nunchucks.lua
+++ b/src/nodes/weapons/nunchucks.lua
@@ -13,7 +13,7 @@ return{
     frameAmt = 3,
     width = 50,
     height = 40,
-    dropWidth = 24,
+    dropWidth = 10,
     dropHeight = 34,
     damage = 2,
     special_damage = {blunt = 1},


### PR DESCRIPTION
If the player isn't holding the item, there's no reason to offset the bounding box or use the item properties for width or height. We use no offset and the node width and height from the tmx instead until the player picks up the item.
