### PR TITLE
Player effects reset after death

### DIFF
--- a/src/level.lua
+++ b/src/level.lua
@@ -498,6 +498,7 @@ function Level:update(dt)
         self.player:saveData( gamesave )
         self.over = true
         self.respawn = Timer.add(3, function()
+            self.player:resetEffects()
             self.player.character:reset()
             local point = gamesave:get('savepoint', {level='studyroom', name='bookshelf'})
             if app.config.hardcore then

--- a/src/player.lua
+++ b/src/player.lua
@@ -616,10 +616,53 @@ function Player:hurt(damage)
     self:startBlink()
 end
 
+function Player:addEffectsTimer(timer)
+  self.timers = self.timers or {}
+  self.timers[#self.timers+1] = timer
+end
+
+function Player:initEffectsReset()
+  if not self.resetPlayerEffects then
+    self.resetValues = {
+      punchDamage = self.punchDamage,
+      jumpFactor = self.jumpFactor,
+      jumpDamage = self.jumpDamage,
+      slideDamage = self.slideDamage,
+      speedFactor = self.speedFactor,
+      costume = self.character.costume
+    }
+
+    self.resetPlayerEffects = function ()
+      self.punchDamage = self.resetValues.punchDamage
+      self.jumpFactor = self.resetValues.jumpFactor
+      self.jumpDamage = self.resetValues.jumpDamage
+      self.slideDamage = self.resetValues.slideDamage
+      self.speedFactor = self.resetValues.speedFactor
+      self.character.costume = self.resetValues.costume
+    end
+  end
+
+  return self.resetValues.punchDamage,
+    self.resetValues.jumpFactor,
+    self.resetValues.jumpDamage,
+    self.resetValues.slideDamage,
+    self.resetValues.speedFactor,
+    self.resetValues.costume
+end
+
+function Player:resetEffects()
+  if self.resetPlayerEffects then
+    self.resetPlayerEffects()
+  end
+  for _,timer in pairs(self.timers) do
+    Timer.cancel(timer)
+  end
+end
+
 function Player:potionFlash(duration,color)
     self:stopBlink()
     self.color = color
-		self.potion = true
+        self.potion = true
 
     Timer.add(duration, function() 
         self.potion = false

--- a/src/playerEffects.lua
+++ b/src/playerEffects.lua
@@ -61,32 +61,27 @@ function PlayerEffects:randEffect(player, effects)
 end
 
 function PlayerEffects.zombie(player)
-  local punchDamage = player.punchDamage
-  local jumpDamage = player.jumpDamage
-  local slideDamage = player.slideDamage
-  local costume = player.character.costume
-  Timer.add(66, function () --Resets damage boost and costume after one minute being active
+  local punchDamage, jumpFactor, jumpDamage, slideDamage, speedFactor, costume = player:initEffectsReset()
+
+  player:addEffectsTimer(Timer.add(66, function () --Resets damage boost and costume after one minute being active
     HUDMessage("a chilling gust of AC makes you forget your hunger for brains", player, 10)
-    player.punchDamage = punchDamage
-    player.jumpDamage = jumpDamage
-    player.slideDamage = slideDamage
-    player.character.costume = costume
-  end)
+    player.resetPlayerEffects()
+  end))
   HUDMessage("that taco meat tastes weird...", player)
   for i=1,2 do
-    Timer.add(2*i-1, function () -- Damage over time
+    player:addEffectsTimer(Timer.add(2*i-1, function () -- Damage over time
       if player.health > 1 then player:hurt(15) end
-    end)
+    end))
   end
-  Timer.add(6, function () -- Set costume to zombie and double unarmed player damage.
+  player:addEffectsTimer(Timer.add(6, function () -- Set costume to zombie and double unarmed player damage.
     if love.filesystem.exists("images/characters/" .. player.character.name .. "/zombie.png") then
       player.character.costume = 'zombie'
     end
     HUDMessage("holy crap, you are a zombie!", player, 10)
-    player.jumpDamage = player.jumpDamage * 2
-    player.punchDamage = player.punchDamage * 2
-    player.slideDamage = player.slideDamage * 2
-  end)
+    player.jumpDamage = jumpDamage * 2
+    player.punchDamage = punchDamage * 2
+    player.slideDamage = slideDamage * 2
+  end))
 end
 
 function PlayerEffects.dudEffect(item, player)
@@ -94,27 +89,23 @@ function PlayerEffects.dudEffect(item, player)
 end
 
 function PlayerEffects.alcohol(player)
-  local punchDamage = player.punchDamage
-  local jumpFactor = player.jumpFactor
-  local speedFactor = player.speedFactor
+  local punchDamage, jumpFactor, jumpDamage, slideDamage, speedFactor, costume = player:initEffectsReset()
 
-  Timer.add(40, function () --Resets everything
+  player:addEffectsTimer(Timer.add(40, function () --Resets everything
     HUDMessage("Sobering up", player)
-    player.punchDamage = punchDamage
-    player.jumpFactor = jumpFactor
-    player.speedFactor = speedFactor
-  end)
+    player.resetPlayerEffects()
+  end))
 
   HUDMessage("I think you drank too much...", player)
   player.jumpFactor = jumpFactor * (math.random(40, 80) / 100)
   player.punchDamage = punchDamage * (math.random(40, 80) / 100)
   player.speedFactor = speedFactor * (math.random(40, 80) / 100)
 
-  Timer.addPeriodic(10, function()
+  player:addEffectsTimer(Timer.addPeriodic(10, function()
       player.jumpFactor = jumpFactor * (math.random(40, 80) / 100)
       player.punchDamage = punchDamage * (math.random(40, 80) / 100)
       player.speedFactor = speedFactor * (math.random(40, 80) / 100)
-  end, 3)
+  end, 3))
 
 end
 


### PR DESCRIPTION
Storing player effect timers in a table inside the player node allows us to cancel them on death. Also storing some reset values whenever a new effect is added to the player means that we can add as many effects as we want all at once without anything breaking.

Previously, becoming a zombie and then getting drunk would mean that the drunk player effect was based on the values of being a zombie. So if the zombie effect was running twice as fast, and becoming drunk was running twice as fast. Having both effects would cause the player to run exponentially faster rather than simply twice as fast.

Resolves #2194.
