### PR TITLE
Enemies will stop themselves from overlapping - WIP

### DIFF
--- a/src/nodes/enemies/hippy.lua
+++ b/src/nodes/enemies/hippy.lua
@@ -53,7 +53,7 @@ return {
       enemy.velocity.x = 0
     else
       local direction = enemy.direction == 'left' and 1 or -1
-      enemy.velocity.x =  direction * enemy.props.speed
+      enemy.velocity.x =  direction * enemy.speed
     end
     if enemy.floor then
       if enemy.position.y < enemy.floor then


### PR DESCRIPTION
![enemy_overlap](https://cloud.githubusercontent.com/assets/39169/4416659/660ed53a-4546-11e4-9992-278ea770a2b6.png)

This is still a work in progress and not entirely perfect, but I wanted to share my progress in resolving #2036.

I've added some code to check for the existence of an enemy colliding with another enemy in front of it and told any enemies following the leader enemy to cease movement. I've started out testing with the hippies in the hallway for now.

I still need to refactor some of the enemy movement and decide which enemies this method should apply to. The hippies are an easy place to start for now and I'll progressively make improvements on the method as I add more enemies to use this movement method. Turkeys are probably next up.

---

**Testing**

You can let them attack you and try to let them build up in a pack, but they should all remain relatively evenly spaced apart. Jumping back and forth over top of a couple hippies in master enough times will also cause them to slowly merge and overlap.

**Notes**

You'll also notice that I've disabled the player getting knocked back from enemies temporarily in this pull request. It just feels nicer to me to have it closer to the episode for how hippies attack. This is intentional and I'd like us to consider having this be an option for some enemies not to knock back the player.