### PR TITLE
Reset player x velocity when they freeze

### DIFF
--- a/src/player.lua
+++ b/src/player.lua
@@ -344,7 +344,13 @@ function Player:update( dt )
     self.attack_box:update()
     
     if self.freeze then
-        return
+        self.velocity.x = 0
+        self.character.state = self.idle_state
+        -- Just in case the player is in the air
+        -- let them fall the rest of the way until we freeze them
+        if self.velocity.y == 0 then
+            return
+        end
     end
 
     local controls = self.controls


### PR DESCRIPTION
Resolves #2236.

When a dialog opens, reset player x velocity so they don't continue running after exiting dialog. Also allow the player to continue falling if they opened a dialog in mid-air.
