### PR TITLE
Fixes oversized error message

### DIFF
--- a/src/main.lua
+++ b/src/main.lua
@@ -2,10 +2,12 @@ local utils = require 'utils'
 local app = require 'app'
 
 function love.errhand(msg)
+  love.graphics.pop()
   app:errhand(msg)
 end
 
 function love.releaseerrhand(msg)
+  love.graphics.pop()
   app:releaseerrhand(msg)
 end
 


### PR DESCRIPTION
Fixes #2221 

To test: create a bug in welcome.lua eg. ask it to draw self.arrw instead of self.arrow. This should give an oversized error message in master.
