### PR TITLE
Use Scissors instead of Stencils for performance

### DIFF
--- a/src/nodes/splat.lua
+++ b/src/nodes/splat.lua
@@ -28,27 +28,24 @@ function Splat:setup_stencils()
   self.map_width = gs.currentState().map.width * gs.currentState().map.tilewidth
 
   self.stencils = {
-    ceiling = function()
-        love.graphics.rectangle('fill',
-                    self.ceiling.x,
-                    self.ceiling.y,
-                    self.map_width,
-                    self.ceiling.height )
-      end,
-    wall = function()
-        love.graphics.rectangle('fill',
-                    self.ceiling.x,
-                    self.ceiling.y + self.ceiling.height,
-                    self.map_width,
-                    self.floor.y - ( self.ceiling.y + self.ceiling.height ) )
-      end,
-    floor = function()
-        love.graphics.rectangle('fill',
-                    self.floor.x,
-                    self.floor.y,
-                    self.map_width,
-                    self.floor.height )
-      end
+    ceiling = {
+      x = self.ceiling.x,
+      y = self.ceiling.y,
+      width = self.map_width,
+      height = self.ceiling.height * 2
+    },
+    wall = {
+      x = self.ceiling.x,
+      y = self.ceiling.y + self.ceiling.height * 2,
+      width = self.map_width,
+      height = self.floor.y * 2 - ( self.ceiling.y + self.ceiling.height * 2 )
+    },
+    floor = {
+      x = self.floor.x,
+      y = self.floor.y * 2,
+      width = self.map_width,
+      height = self.floor.height * 2
+    }
   }
 end
 
@@ -78,7 +75,7 @@ function Splat:draw()
   if self.stencils then
     love.graphics.setColor( 255, 255, 255, 255 )
 
-    love.graphics.setStencil( self.stencils.wall )
+    love.graphics.setScissor( self.stencils.wall.x, self.stencils.wall.y, self.stencils.wall.width, self.stencils.wall.height)
     for _,s in pairs( self.splats ) do
       love.graphics.draw( splatters,
                  quads[s.index],
@@ -91,7 +88,7 @@ function Splat:draw()
 
     love.graphics.setColor( 200, 200, 200, 255 )  -- Giving darker shade to splash on ceiling and floor
 
-    love.graphics.setStencil( self.stencils.floor )
+    love.graphics.setScissor( self.stencils.floor.x, self.stencils.floor.y, self.stencils.floor.width, self.stencils.floor.height )
     for _,s in pairs( self.splats ) do
       love.graphics.draw( splatters,
                  quads[s.index],
@@ -104,7 +101,7 @@ function Splat:draw()
                  -1, 0 )
     end
 
-    love.graphics.setStencil( self.stencils.ceiling )
+    love.graphics.setScissor( self.stencils.ceiling.x, self.stencils.ceiling.y, self.stencils.ceiling.width, self.stencils.ceiling.height )
     for _,s in pairs( self.splats ) do
       love.graphics.draw( splatters,
                  quads[s.index],
@@ -118,7 +115,7 @@ function Splat:draw()
     end
 
     love.graphics.setColor( 255, 255, 255, 255 )
-    love.graphics.setStencil()
+    love.graphics.setScissor()
 
   end
 end


### PR DESCRIPTION
Specifically I'm interested in @edisonout trying this out to see if it improves the performance problems in the hallway as the splatters are added to the level. I know for me that every hippy I kill in the hallway slowly drops the framerate because of all the stencil drawing.

Also, I'm not sure why the height calculations are off and need to be multiplied by a factor of 2 in order to work. Anyone have any ideas?
