### PR TITLE
Fix colliding with half tiles when they are next to slopes

### DIFF
--- a/src/hawk/collision.lua
+++ b/src/hawk/collision.lua
@@ -107,7 +107,7 @@ end
 -- Also, remember that tile ids are indexed startin at 1
 -- We assume that the tile at tile_index is sloped
 function module.is_adjacent(current_index, current_id, tile_index, tile_id, direction)
-  if tile_id ~= 0 then
+  if tile_id ~= 0 and not module.is_special(tile_id) then
     return false
   end
 
@@ -195,7 +195,6 @@ function module.move_x(map, player, x, y, width, height, dx, dy)
                                             tile.id, direction)
       end
 
-      -- special blocks only collide on the y axis
       local ignore = sloped or adjacent_slope
       
       if direction == "left" then

--- a/src/maps/new-abedtown.tmx
+++ b/src/maps/new-abedtown.tmx
@@ -146,7 +146,7 @@
  </layer>
  <layer name="collision" width="68" height="19">
   <data encoding="base64" compression="zlib">
-   eJzt1cEJwCAMhWFHdxFpoRt46RIOpV6LsUiqNfB/8C7qIVEwzgEAsI/7EWn9bR8AsEaYdNYyaWYxq2BdEmJFUOZYXG/vzyi1eG0/X9De5VkSG7kGaqh3oetiD713+eNtM2aBRww=
+   eJzt1cEJwCAMheHsv4O20A28dAmH0nNplBIbDPwfvIt6iAaMCAAA+7gf0dZn+wAAH+mns5FpM4tZheiqkiiSMYdzvaM/I4v9PitY3/LsKS+5PtSQjXfYxawn3r1t6phE0A==
   </data>
  </layer>
 </map>


### PR DESCRIPTION
Fixes one of the issue mentioned in #2247 

This was an oversight on my part, luckily it was a simple fix.

I also fixed a tile issue in new-abedtown, some of the slope tiles were reversed.
