### PR TITLE
Only show dealer dialog once in tavern

### DIFF
--- a/src/nodes/dealer.lua
+++ b/src/nodes/dealer.lua
@@ -23,14 +23,16 @@ function Dealer.new(node, collider)
   return dealer
 end
 
-function Dealer:enter(dt)
+function Dealer:enter(previous)
   fonts.reset()
 
   --Dealer says "Let's play poker" after a few seconds when player enters the tavern.
-  self.dialog = Timer.add(math.random(3,4), function()
-    poker = Dialog.new("Let's play {{yellow}}poker{{white}}.")
-    sound.playSfx("letsPlayPoker")
-  end)
+  if not self.dialog then
+    self.dialog = Timer.add(math.random(3,4), function()
+      poker = Dialog.new("Let's play {{yellow}}poker{{white}}.")
+      sound.playSfx("letsPlayPoker")
+    end)
+  end
 end
 
 function Dealer:leave()


### PR DESCRIPTION
Resolves #2269. Since the dialog timer is already created once, we make sure that we don't create multiple timers and therefore the timer can be properly cancelled when leaving the level.
