### PR TITLE
Add Quest module and migrate existing quests

### DIFF
--- a/src/npcs/hilda.lua
+++ b/src/npcs/hilda.lua
@@ -10,12 +10,14 @@ local Dialog = require 'dialog'
 local prompt = require 'prompt'
 local controls = require('inputcontroller').get()
 local Emotion = require 'nodes/emotion'
+local Quest = require 'quest'
+local quests = require 'npcs/quests/hildaquest'
 
 return {
   width = 32,
-  height = 48, 
+  height = 48,
   run_offsets = {{x=700, y=0}, {x=620, y=0}},
-  greeting = 'I am {{red_light}}Hilda{{white}}, I live in the {{olive}}village{{white}}.', 
+  greeting = 'I am {{red_light}}Hilda{{white}}, I live in the {{olive}}village{{white}}.',
   animations = {
     default = {
       'loop',{'1,1','11,1'},.5,
@@ -199,50 +201,8 @@ return {
   { ['text']='stand aside' },
   },
   talk_commands = {
-    ['flowers']=function(npc, player)
-      npc.walking = false
-      npc.stare = false
-      if player.quest~=nil and player.quest~='collect flowers' then
-        Dialog.new("You already have quest '" .. player.quest .. "' for {{red_light}}" .. player.questParent .. "{{white}}!", function()
-          npc.walking = true
-          npc.menu:close(player)
-        end)
-      elseif player.quest=='collect flowers' and not player.inventory:hasMaterial('flowers') then
-        Dialog.new("Have you found any flowers?  Try looking beyond the town.", function()
-          npc.walking = true
-          npc.menu:close(player)
-        end)
-      elseif player.quest=='collect flowers' and player.inventory:hasMaterial('flowers') then
-        Dialog.new("My goodness, these flowers are beautiful!  Thank you so very much!", function()
-          npc:affectionUpdate(300)
-          player:affectionUpdate('hilda',300)
-          npc.walking = true
-          player.inventory:removeManyItems(1,{name='flowers',type='material'})
-          player.quest = nil
-          npc.menu:close(player)
-        end)
-      else
-        local script = {
-          "I love {{teal}}flowers{{white}}!",
-          "I used to collect {{teal}}flowers{{white}} from the {{olive}}forest{{white}} beyond the {{green_light}}blacksmith{{white}} but ever since {{grey}}Hawkthorne{{white}} started ruling the {{olive}}forests{{white}} haven't been safe.",
-          "I would be so happy if someone could pick me some!",
-        }
-        Dialog.new(script, function()
-          npc.prompt = prompt.new("Do you want to collect flowers for {{red_light}}Hilda{{white}}?", function(result)
-            if result == 'Yes' then
-              player.quest = 'collect flowers'
-              player.questParent = 'hilda'
-            end
-            npc.menu:close(player)
-            npc.fixed = result == 'Yes'
-            npc.walking = true
-            npc.prompt = nil
-            Timer.add(2, function()
-              npc.fixed = false
-            end)
-          end)
-        end)
-      end
+    ['flowers'] = function (npc, player)
+      Quest:activate(npc, player, quests.flowers)
     end,
     ['for your hand']=function(npc, player)
       local affection = player.affection.hilda or 0

--- a/src/npcs/juanita.lua
+++ b/src/npcs/juanita.lua
@@ -2,11 +2,13 @@
 local Dialog = require 'dialog'
 local prompt = require 'prompt'
 local Timer = require('vendor/timer')
+local Quest = require 'quest'
+local quests = require 'npcs/quests/juanitaquest'
 
 return {
   width = 32,
   height = 48,
-  greeting = 'I am {{red_light}}Juanita{{white}}, I live in {{olive}}Tacotown{{white}}.', 
+  greeting = 'I am {{red_light}}Juanita{{white}}, I live in {{olive}}Tacotown{{white}}.',
   animations = {
     default = {
       'loop',{'11,1','11,1','11,1','10,1'},.5,
@@ -27,43 +29,9 @@ return {
     }},
   },
   talk_commands = {
-    ['You look very busy']=function(npc, player)
-      if player.quest~=nil and player.quest~='clean up town' then
-        Dialog.new("You already have quest '" .. player.quest .. "' for {{red_light}}" .. player.questParent .. "{{white}}!", function()
-          npc.menu:close(player)
-        end)
-      elseif player.quest=='clean up town' and not player.inventory:hasConsumable('alcohol') then
-        Dialog.new("This place is a filthy!", function()
-          npc.menu:close(player)
-        end)
-      elseif player.quest=='clean up town' and player.inventory:hasConsumable('alcohol') then
-        Dialog.new("Thanks for helping clean up!  The town looks so much nicer!", function()
-          npc:affectionUpdate(player:affectionUpdate('juanita',100))
-          player.inventory:removeManyItems(1,{name='alcohol',type='consumable'})
-          player.quest = nil
-          npc.menu:close(player)
-        end)
-      else
-        local script = {
-          "Of course I am! Look at all this mess I have to clean up! It sucks being a cleaning person around these parts.",
-          "You know, I am pretty darn sure that I'm the only one who does an honest day's work in this town.",
-        }
-        Dialog.new(script, function()
-          npc.prompt = prompt.new("Can you help me clean up by picking up some bottles?", function(result)
-            if result == 'Yes' then
-              player.quest = 'clean up town'
-              player.questParent = 'juanita'
-            end
-            npc.menu:close(player)
-            npc.fixed = result == 'Yes'
-            npc.prompt = nil
-            Timer.add(2, function()
-              npc.fixed = false
-            end)
-          end)
-        end)
-      end
-    end,
+    ['You look very busy']= function(npc, player)
+        Quest:activate(npc, player, quests.alcohol)
+      end,
   },
   talk_responses = {
     ['Any useful info for me?']={

--- a/src/npcs/quests/hildaquest.lua
+++ b/src/npcs/quests/hildaquest.lua
@@ -1,0 +1,21 @@
+-- hildaquest.lua
+
+local quests = {
+  flowers = {
+    questName = 'collect flowers',
+    questParent = 'hilda',
+    collect = {name = 'flowers', type = 'material'},
+    --prompt: 'flowers'
+    giveQuestSucceed = {
+        "I love {{teal}}flowers{{white}}!",
+        "I used to collect {{teal}}flowers{{white}} from the {{olive}}forest{{white}} beyond the {{green_light}}blacksmith{{white}} but ever since {{grey}}Hawkthorne{{white}} started ruling the {{olive}}forests{{white}} haven't been safe.",
+        "I would be so happy if someone could pick me some!",
+      },
+    successPrompt = "Do you want to collect flowers for {{red_light}}Hilda{{white}}?",
+    completeQuestFail = "Have you found any flowers? Try looking beyond the town.",
+    completeQuestSucceed = "My goodness, these flowers are beautiful!  Thank you so very much!",
+    reward = {affection = 300},
+  },
+}
+
+return quests

--- a/src/npcs/quests/juanitaquest.lua
+++ b/src/npcs/quests/juanitaquest.lua
@@ -1,0 +1,20 @@
+-- juanitaquest.lua
+
+local quests = {
+  alcohol = {
+    questName = 'clean up town',
+    questParent = 'juanita',
+    collect = {name = 'alcohol', type = 'consumable'},
+    --prompt: 'You look very busy'
+    giveQuestSucceed = {
+      "Of course I am! Look at all this mess I have to clean up! It sucks being a cleaning person around these parts.",
+      "You know, I am pretty darn sure that I'm the only one who does an honest day's work in this town.",
+    },
+    successPrompt = "Can you help me clean up by picking up some bottles?",
+    completeQuestFail = "This place is filthy!",
+    completeQuestSucceed = "Thanks for helping clean up!  The town looks so much nicer!",
+    reward = {affection = 100},
+  },
+}
+
+return quests

--- a/src/quest.lua
+++ b/src/quest.lua
@@ -34,7 +34,14 @@ function Quest.giveQuestFail(npc, player, quest)
   local script = "You already have quest '" .. player.quest .. "' for {{red_light}}" .. player.questParent .. "{{white}}!"
   script = quest.giveQuestFail or script
   Dialog.new(script, function()
-    npc.menu:close(player)
+    npc.prompt = prompt.new("Abandon current quest?", function(result)
+      if result == 'Yes' then
+        player.quest = nil
+        player.questParent = quest.questParent
+      end
+      npc.menu:close(player)
+      npc.prompt = nil
+    end)
   end)
 end
 

--- a/src/quest.lua
+++ b/src/quest.lua
@@ -1,0 +1,83 @@
+-- quest.lua
+
+local Dialog = require 'dialog'
+local prompt = require 'prompt'
+
+
+local Quest = {}
+
+function Quest:activate(npc, player, quest)
+  if not player.quest then
+    self.giveQuestSucceed(npc,player,quest)
+  elseif player.quest == quest.questName then
+    self:completeQuest(npc,player,quest)
+  else
+    self.giveQuestFail(npc,player,quest)
+  end
+end
+
+function Quest.giveQuestSucceed(npc, player, quest)
+  local script = quest.giveQuestSucceed
+  Dialog.new (script, function()
+    npc.prompt = prompt.new(quest.successPrompt, function(result)
+      if result == 'Yes' then
+        player.quest = quest.questName
+        player.questParent = quest.questParent
+      end
+      npc.menu:close(player)
+      npc.prompt = nil
+    end)
+  end)
+end
+
+function Quest.giveQuestFail(npc, player, quest)
+  local script = "You already have quest '" .. player.quest .. "' for {{red_light}}" .. player.questParent .. "{{white}}!"
+  script = quest.giveQuestFail or script
+  Dialog.new(script, function()
+    npc.menu:close(player)
+  end)
+end
+
+
+function Quest:completeQuest(npc, player, quest)
+  local success = self.testSuccess(player, quest)
+  if success then
+    self.completeQuestSucceed(npc, player, quest)
+  else
+    self.completeQuestFail(npc, player, quest)
+  end
+end
+
+function Quest.testSuccess(player, quest)
+  local success = false
+  if quest.collect then
+    if quest.collect.type == 'consumable' then
+      success = player.inventory:hasConsumable(quest.collect.name)
+    elseif quest.collect.type == 'material' then
+      success = player.inventory:hasMaterial(quest.collect.name)
+    end
+  end
+  return success
+end
+
+function Quest.completeQuestFail(npc, player, quest)
+  Dialog.new(quest.completeQuestFail, function()
+    npc.menu:close(player)
+  end)
+end
+
+function Quest.completeQuestSucceed(npc, player, quest)
+  Dialog.new(quest.completeQuestSucceed, function()
+    if quest.reward.affection then
+      npc:affectionUpdate(quest.reward.affection)
+      player:affectionUpdate(quest.questParent, quest.reward.affection)
+    end
+    if quest.collect then
+      player.inventory:removeManyItems(1, quest.collect)
+    end
+    player.quest = nil
+    npc.menu:close(player)
+  end)
+end
+
+return Quest


### PR DESCRIPTION
Adding new collection quests should be dead simple now.

Additionally, expanding the module to permit other types of quests can be accomplished by adding to testSuccess and completeQuestSucceed.

Let me know if there are any features you want me to add before we merge this.