### PR TITLE
Powershell arguments

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -82,7 +82,11 @@ foreach($fileName in $fileEntries)
 
 if($args[0] -eq "run"){
   Write-Host "Running Journey to the Center of Hawkthorne..."
-  .\bin\love-0.9.1-win32\love.exe src $args[1..($args.Length-1)]
+  if($args.Length -ne 1){
+    .\bin\love-0.9.1-win32\love.exe src $args[1..($args.Length-1)]
+  }else{
+    .\bin\love-0.9.1-win32\love.exe src
+  }
 }elseif($args[0] -eq "test"){
   Write-Host "Testing Journey to the Center of Hawkthorne..."
   .\bin\love-0.9.1-win32\love.exe src --test --console

--- a/make.ps1
+++ b/make.ps1
@@ -82,7 +82,7 @@ foreach($fileName in $fileEntries)
 
 if($args[0] -eq "run"){
   Write-Host "Running Journey to the Center of Hawkthorne..."
-  .\bin\love-0.9.1-win32\love.exe src
+  .\bin\love-0.9.1-win32\love.exe src $args[1..($args.Length-1)]
 }elseif($args[0] -eq "test"){
   Write-Host "Testing Journey to the Center of Hawkthorne..."
   .\bin\love-0.9.1-win32\love.exe src --test --console


### PR DESCRIPTION
This allows for extra arguments to be added to ```./make.ps1 run``` which are then passed to the hawkthorne file. For example, ```./make.ps1 run --console -b -l forest``` is now possible, and is equivalent to ```.\bin\love-0.9.1-win32\love.exe src --console -b -l forest```.