### PR TITLE
Improve hippies in hallway

### DIFF
--- a/src/maps/hallway.tmx
+++ b/src/maps/hallway.tmx
@@ -86,6 +86,6 @@
   </object>
  </objectgroup>
  <objectgroup name="ceiling" width="100" height="14">
-  <object type="ceiling" x="24" y="0" width="2400" height="72"/>
+  <object type="ceiling" x="0" y="0" width="2400" height="72"/>
  </objectgroup>
 </map>

--- a/src/maps/hallway.tmx
+++ b/src/maps/hallway.tmx
@@ -58,7 +58,11 @@
     <property name="trigger" value="cuttriggers.throne"/>
    </properties>
   </object>
-  <object type="ceiling_hippy" x="360" y="24" width="48" height="24"/>
+  <object type="ceiling_hippy" x="528" y="24" width="48" height="24">
+   <properties>
+    <property name="prob" value="0.2"/>
+   </properties>
+  </object>
   <object type="ceiling_hippy" x="768" y="24" width="48" height="24"/>
   <object type="ceiling_hippy" x="984" y="24" width="48" height="24"/>
   <object type="ceiling_hippy" x="1896" y="24" width="48" height="24">
@@ -82,6 +86,27 @@
    <properties>
     <property name="delay" value="1"/>
     <property name="proximity" value="80"/>
+   </properties>
+  </object>
+  <object type="ceiling_hippy" x="360" y="24" width="48" height="24"/>
+  <object type="ceiling_hippy" x="1080" y="24" width="48" height="24">
+   <properties>
+    <property name="prob" value="0.2"/>
+   </properties>
+  </object>
+  <object type="ceiling_hippy" x="1344" y="24" width="48" height="24">
+   <properties>
+    <property name="prob" value="0.2"/>
+   </properties>
+  </object>
+  <object type="ceiling_hippy" x="1656" y="24" width="48" height="24">
+   <properties>
+    <property name="prob" value="0.2"/>
+   </properties>
+  </object>
+  <object type="ceiling_hippy" x="2016" y="24" width="48" height="24">
+   <properties>
+    <property name="prob" value="0.2"/>
    </properties>
   </object>
  </objectgroup>

--- a/src/maps/hallway.tmx
+++ b/src/maps/hallway.tmx
@@ -35,6 +35,7 @@
     <property name="to" value="main"/>
    </properties>
   </object>
+  <object type="splat" x="2376" y="0" width="24" height="24"/>
   <object name="main" type="door" x="144" y="240" width="24" height="48">
    <properties>
     <property name="level" value="studyroom"/>
@@ -57,61 +58,34 @@
     <property name="trigger" value="cuttriggers.throne"/>
    </properties>
   </object>
-  <object type="splat" x="2376" y="0" width="24" height="24"/>
-  <object type="enemy" x="312" y="240" width="48" height="48">
-   <properties>
-    <property name="enemytype" value="hippy"/>
-   </properties>
-  </object>
-  <object type="enemy" x="600" y="240" width="48" height="48">
-   <properties>
-    <property name="enemytype" value="hippy"/>
-   </properties>
-  </object>
-  <object type="enemy" x="1008" y="240" width="48" height="48">
-   <properties>
-    <property name="enemytype" value="hippy"/>
-   </properties>
-  </object>
-  <object type="enemy" x="1152" y="240" width="48" height="48">
-   <properties>
-    <property name="enemytype" value="hippy"/>
-   </properties>
-  </object>
-  <object type="enemy" x="1296" y="240" width="48" height="48">
-   <properties>
-    <property name="enemytype" value="hippy"/>
-   </properties>
-  </object>
-  <object type="enemy" x="1968" y="240" width="48" height="48">
-   <properties>
-    <property name="enemytype" value="hippy"/>
-   </properties>
-  </object>
-  <object type="enemy" x="2040" y="240" width="48" height="48">
-   <properties>
-    <property name="enemytype" value="hippy"/>
-   </properties>
-  </object>
-  <object type="enemy" x="2184" y="240" width="48" height="48">
-   <properties>
-    <property name="enemytype" value="hippy"/>
-   </properties>
-  </object>
-  <object type="enemy" x="2112" y="240" width="48" height="48">
-   <properties>
-    <property name="enemytype" value="hippy"/>
-   </properties>
-  </object>
   <object type="ceiling_hippy" x="360" y="24" width="48" height="24"/>
-  <object type="ceiling_hippy" x="696" y="24" width="48" height="24"/>
-  <object type="ceiling_hippy" x="456" y="24" width="48" height="24"/>
-  <object type="ceiling_hippy" x="1008" y="24" width="48" height="24"/>
-  <object type="ceiling_hippy" x="1704" y="24" width="48" height="24"/>
-  <object type="ceiling_hippy" x="2112" y="24" width="48" height="24"/>
-  <object type="ceiling_hippy" x="576" y="24" width="48" height="24"/>
+  <object type="ceiling_hippy" x="768" y="24" width="48" height="24"/>
+  <object type="ceiling_hippy" x="984" y="24" width="48" height="24"/>
+  <object type="ceiling_hippy" x="1896" y="24" width="48" height="24">
+   <properties>
+    <property name="proximity" value="50"/>
+   </properties>
+  </object>
+  <object type="ceiling_hippy" x="1512" y="24" width="48" height="24">
+   <properties>
+    <property name="delay" value="0"/>
+    <property name="proximity" value="50"/>
+   </properties>
+  </object>
+  <object type="ceiling_hippy" x="2256" y="24" width="48" height="24"/>
+  <object type="ceiling_hippy" x="864" y="24" width="48" height="24">
+   <properties>
+    <property name="proximity" value="500"/>
+   </properties>
+  </object>
+  <object type="ceiling_hippy" x="1248" y="24" width="48" height="24">
+   <properties>
+    <property name="delay" value="1"/>
+    <property name="proximity" value="80"/>
+   </properties>
+  </object>
  </objectgroup>
  <objectgroup name="ceiling" width="100" height="14">
-  <object type="ceiling" x="0" y="0" width="2400" height="72"/>
+  <object type="ceiling" x="24" y="0" width="2400" height="72"/>
  </objectgroup>
 </map>

--- a/src/nodes/ceiling_hippy.lua
+++ b/src/nodes/ceiling_hippy.lua
@@ -1,5 +1,6 @@
 local anim8 = require 'vendor/anim8'
 local sound = require 'vendor/TEsound'
+local Timer = require 'vendor/timer'
 local gamestate = require 'vendor/gamestate'
 local enemy = require 'nodes/enemy'
 
@@ -17,7 +18,10 @@ function CeilingHippie.new( node, collider )
   ceilinghippie.collider = collider
   ceilinghippie.width = 48
   ceilinghippie.height = 48
+  ceilinghippie.proximity = tonumber(node.properties.proximity) or 30
+  ceilinghippie.drop_delay = tonumber(node.properties.delay) or 0.2
   ceilinghippie.dropped = false
+  ceilinghippie.dropping = false
 
   -- This prevents every hippie from dropping
   local p = tonumber(node.properties.prob) or 0.6
@@ -32,17 +36,22 @@ end
 
 function CeilingHippie:update(dt, player)
   if not self.dropped then
-    local playerdistance = math.abs(player.position.x - self.node.x) - self.width/2 - player.bbox_width/2
-    if self.can_drop and playerdistance <= 24 then
-      sound.playSfx( 'hippy_enter' )
+    local player_x = player.position.x - player.character.bbox.x
 
-      local level = gamestate.currentState()
-      local node = enemy.new( self.node, self.collider, 'hippy' )
-      level:addNode(node)
-      self.hippie = node
+    local playerdistance = math.abs(player_x - self.node.x) - self.width/2 - player.character.bbox.width/2
+    if self.can_drop and playerdistance <= self.proximity then
+      self.dropping = true
+      Timer.add(self.drop_delay, function()
+        sound.playSfx( 'hippy_enter' )
 
-      self.hippie.position = {x=self.node.x + 12, y=self.node.y}
-      self.hippie.velocity.y = 300
+        local level = gamestate.currentState()
+        local node = enemy.new( self.node, self.collider, 'hippy' )
+        level:addNode(node)
+        self.hippie = node
+
+        self.hippie.position = {x=self.node.x + 12, y=self.node.y}
+        self.hippie.velocity.y = 300
+      end)
       
       self.dropped = true
     end
@@ -50,9 +59,12 @@ function CeilingHippie:update(dt, player)
 end
 
 function CeilingHippie:draw()
-  if not self.dropped then return end
+  if not self.dropping then return end
   
   love.graphics.draw( open_ceiling, self.node.x - 24, self.node.y )
+
+  if not self.dropped then return end
+  
   love.graphics.draw( broken_tiles, self.node.x - 24, self.floor + self.node.height * 2 )
 end
 

--- a/src/nodes/ceiling_hippy.lua
+++ b/src/nodes/ceiling_hippy.lua
@@ -18,6 +18,10 @@ function CeilingHippie.new( node, collider )
   ceilinghippie.width = 48
   ceilinghippie.height = 48
   ceilinghippie.dropped = false
+
+  -- This prevents every hippie from dropping
+  local p = tonumber(node.properties.prob) or 0.6
+  ceilinghippie.can_drop = math.random() < p 
   
   return ceilinghippie
 end
@@ -29,7 +33,7 @@ end
 function CeilingHippie:update(dt, player)
   if not self.dropped then
     local playerdistance = math.abs(player.position.x - self.node.x) - self.width/2 - player.bbox_width/2
-    if playerdistance <= 24 then
+    if self.can_drop and playerdistance <= 24 then
       sound.playSfx( 'hippy_enter' )
 
       local level = gamestate.currentState()


### PR DESCRIPTION
I'm making this pull request primarily for the purpose of displaying some techniques to make the hippies less frustrating and more fun to play.
Ideally this would merged together with #2307 before being merged into master but that is up for debate.

The purpose here is not to nerf the hallway but to make the hippies feel more like they did in the episode and provide a gentler entry into hawkthorne for first timers.

Me and @niamu were discussing on irc what we could do to improve the feel of the hallway, without making it to easy. Below is a list of those ideas that I have implemented in this branch.
* Warn the player about an imminent hippy by dropping a tile with a delay before the actual hippy attacks 
* Remove non-ceiling hippies (as this is what was seen in the episode, but doesn't mean you see all hippies drop)
* Varying proximity and delay between hippies to give them more of a dynamic feel

In the ideal case I would like to randomize proximity and delay (within reason) and include #2307 so that the level feels fresh every time, although I would love to get a discussion going about what we do and do not want to see changed about the hallway.

Note: I also fixed an issue where the hippies were not checking the correct position, which was a mistake of mine from the new collisions change.