### PR TITLE
Move ropes in village forest and treeline

### DIFF
--- a/src/maps/village-forest.tmx
+++ b/src/maps/village-forest.tmx
@@ -190,7 +190,7 @@
    </properties>
   </object>
   <object type="climbable" x="2193" y="95" width="5" height="185"/>
-  <object type="climbable" x="2889" y="170" width="5" height="185"/>
+  <object type="climbable" x="2889" y="168" width="5" height="185"/>
   <object type="door" x="3576" y="768" width="24" height="144">
    <properties>
     <property name="instant" value="true"/>

--- a/src/maps/village-treeline.tmx
+++ b/src/maps/village-treeline.tmx
@@ -126,7 +126,7 @@
   <object type="climbable" x="898" y="1366" width="5" height="279"/>
   <object type="climbable" x="992" y="1391" width="6" height="209"/>
   <object type="climbable" x="1161" y="1126" width="6" height="213"/>
-  <object type="climbable" x="1165" y="569" width="7" height="234"/>
+  <object type="climbable" x="1160" y="576" width="7" height="234"/>
   <object type="climbable" x="1112" y="1967" width="6" height="212"/>
   <object type="climbable" x="946" y="552" width="5" height="552"/>
   <object type="climbable" x="680" y="837" width="7" height="219"/>


### PR DESCRIPTION
Each level had a single rope that was mispositioned, this is just a small position change.

The rope in village forest is the last one before the entrance to village treeline.
The rope in village treeline is the highest rope on the right hand side.