### PR TITLE
Lock version to 0.9.1

### DIFF
--- a/src/main.lua
+++ b/src/main.lua
@@ -44,8 +44,8 @@ function love.load(arg)
     error("invalid version label")
   end
 
-  if(not love._version == "0.9.0" and not love.version == "0.9.1") then
-    error("Love 0.9.0 or 0.9.1 is required")
+  if(not love.version == "0.9.1") then
+    error("Love 0.9.1 is required")
   end
 
   -- The Mavericks builds of Love adds too many arguments


### PR DESCRIPTION
No reason not to do this now and it's been around for a while. Re: #2076