### PR TITLE
Crafting weapons of subtype fix

### DIFF
--- a/src/inventory.lua
+++ b/src/inventory.lua
@@ -330,6 +330,11 @@ function Inventory:draw( playerPosition )
         if result then
           local resultFolder = string.lower(result.type)..'s'
           local itemNode = require ('items/' .. resultFolder .. '/' .. result.name)
+          -- this ugly hack shouldn't be necessary, but for whatever reason 
+          -- the type can be overriden by the subtype of the item, so we set type by directory instead
+          if itemNode.directory == 'weapons/' then
+            itemNode.type = 'weapon'
+          end
           local item = Item.new(itemNode)
           item:draw({x=ffPos.x + 83, y=ffPos.y + 19})
         end

--- a/src/items/consumables/deepfrieddud.lua
+++ b/src/items/consumables/deepfrieddud.lua
@@ -11,7 +11,7 @@ return{
   consumable = {
     randEffect = {
       p = {0.4,0.6,0.8,1},
-      {hurt = "half"},
+      {hurt = 0.5},
       {heal = "max"},
       {buff = {
         attribute = "jumpFactor",


### PR DESCRIPTION
As discussed in #2317, this resolves the bizarre problem of the item type we are about to craft being overwritten by the item subtype if you drop that same item from your inventory prior to crafting it again.

I have no idea why this happens as we are requiring new data from the same file every time. It makes no sense and hence the ugly hack.

Also resolves the deep fried dud string/number comparison crash.