### PR TITLE
Allow infinite quests optionally, but not default

### DIFF
--- a/src/npcs/juanita.lua
+++ b/src/npcs/juanita.lua
@@ -30,7 +30,14 @@ return {
   },
   talk_commands = {
     ['You look very busy']= function(npc, player)
-        Quest:activate(npc, player, quests.alcohol)
+      Quest:activate(npc, player, quests.alcohol, function()
+          for _,node in pairs(npc.containerLevel.nodes) do
+            if node.name == 'alcohol' then
+              return true
+            end
+          end
+          return false
+        end)
       end,
   },
   talk_responses = {

--- a/src/npcs/quests/hildaquest.lua
+++ b/src/npcs/quests/hildaquest.lua
@@ -2,6 +2,7 @@
 
 local quests = {
   flowers = {
+    infinite = true,
     questName = 'collect flowers',
     questParent = 'hilda',
     collect = {name = 'flowers', type = 'material'},

--- a/src/npcs/quests/juanitaquest.lua
+++ b/src/npcs/quests/juanitaquest.lua
@@ -2,6 +2,7 @@
 
 local quests = {
   alcohol = {
+    infinite = true,
     questName = 'clean up town',
     questParent = 'juanita',
     collect = {name = 'alcohol', type = 'consumable'},

--- a/src/quest.lua
+++ b/src/quest.lua
@@ -26,7 +26,20 @@ function Quest.alreadyCompleted(npc, player, quest)
   return false
 end
 
-function Quest:activate(npc, player, quest)
+function Quest:activate(npc, player, quest, condition)
+  local meetsCondition = false
+  -- If they aren't on a quest at the moment, check to see if they meet the requirements to accept this one
+  if condition and not player.quest then
+    meetsCondition = condition()
+    if not meetsCondition then
+      -- If they don't meet the conditions to accept the quest, congratulate them
+      -- This is only used for Juanita at the moment and will need changing in the future
+      Dialog.new(quest.completeQuestSucceed, function()
+        npc.menu:close(player)
+      end)
+      return
+    end
+  end
   local completed = self.alreadyCompleted(npc,player,quest)
   if completed and not quest.infinite then
     -- If we've already done this quest, give the player the congrats message without reward


### PR DESCRIPTION
Check for quests that have already been completed. If they have been completed, give congratulations message without rewards.

Hilda's flower quest now has "infinite = true" as an attribute to allow it to be completed many times. Juanita's quest can only be completed once. However we need to make a choice to either not allow the bottles to respawn on entering the level again or only allow the quest to be taken again if there are bottles to pick up in the level. What should the decision be for that?