### PR TITLE
Weapon returns to default position between levels

### DIFF
--- a/src/player.lua
+++ b/src/player.lua
@@ -142,6 +142,7 @@ function Player:refreshPlayer(collider)
     self.currently_held.containerLevel = Gamestate.currentState()
     self.currently_held.containerLevel:addNode(self.currently_held)
     self.currently_held:initializeBoundingBox(collider)
+    self.currently_held.animation = self.currently_held.defaultAnimation
   elseif self.currently_held and (self.currently_held.isVehicle or self.currently_held.isProjectile or self.currently_held.isThrowable) then
     if self.currently_held.isVehicle then
       local vehicle = self.currently_held


### PR DESCRIPTION
If you hit the ATTACK key while wielding a weapon, the weapon will stay in an attack state. Fixed this by returning the animation to the default state on player refresh.