### PR TITLE
Menus can be scrolled by holding down a key

### DIFF
--- a/src/nodes/npc.lua
+++ b/src/nodes/npc.lua
@@ -191,6 +191,7 @@ function Menu:draw(x, y)
 end
 
 function Menu:open(player)
+  love.keyboard.setKeyRepeat( true )
   self.items = self.rootItems
   self.choice = 4
   self.offset = 0
@@ -218,6 +219,7 @@ function Menu:instahide()
 end
 
 function Menu:close(player)
+  love.keyboard.setKeyRepeat( false )
   player.freeze = false
   if self.host.finish then self.host.finish(self.host, player) end
   self.animation:resume()

--- a/src/player.lua
+++ b/src/player.lua
@@ -344,6 +344,12 @@ end
 -- @return nil
 function Player:update(dt, map)
 
+  if Dialog.currentDialog then
+    self.controlState:inventory()
+  else
+    self.controlState:standard()
+  end
+
   self.inventory:update( dt )
   self.attack_box:update()
 


### PR DESCRIPTION
Everyone always comments about wanting to scroll through the list of Hilda's menu by holding down a key or a button.

Player can't move if a dialog is open on screen. This specifically solves the problem of players still being able to move around in the Tavern when the "Let's play poker" dialog appears.