### PR TITLE
Board manages player control state

### DIFF
--- a/src/board.lua
+++ b/src/board.lua
@@ -1,3 +1,4 @@
+local gamestate = require "vendor/gamestate"
 local sound = require 'vendor/TEsound'
 local camera = require 'camera'
 
@@ -25,6 +26,11 @@ function Board.new(width, height)
 end
 
 function Board:open()
+  local state = gamestate.currentState()
+  if state.player then
+    state.player.inventory:close()
+    state.player.controlState:inventory()
+  end
   sound.playSfx( 'menu_expand' )
   self.state = 'opening'
   self.targetWidth = self.maxWidth
@@ -32,6 +38,10 @@ function Board:open()
 end
 
 function Board:close()
+  local state = gamestate.currentState()
+  if not state.scene then
+    if state.player then state.player.controlState:standard() end
+  end
   sound.playSfx( 'menu_close' )
   self.state = 'closing'
   self.targetWidth = 6

--- a/src/player.lua
+++ b/src/player.lua
@@ -344,13 +344,6 @@ end
 -- @param dt The time delta
 -- @return nil
 function Player:update(dt, map)
-
-  if Dialog.currentDialog then
-    self.controlState:inventory()
-  else
-    self.controlState:standard()
-  end
-
   self.inventory:update( dt )
   self.attack_box:update()
 


### PR DESCRIPTION
Resolves #2361 which is a bug I previously created trying to have the player not move when a
dialog is open.