### PR TITLE
Close dealer dialog on leaving level

### DIFF
--- a/src/dialog.lua
+++ b/src/dialog.lua
@@ -45,6 +45,11 @@ function Dialog:open(callback)
   self.state = 'opened'
 end
 
+function Dialog:close()
+  self.board:close()
+  self.state = 'closing'
+end
+
 function Dialog:reposition()
   local state = gamestate.currentState()
 
@@ -131,8 +136,7 @@ function Dialog:keypressed( button )
       self.cursor = 0
       self.line = self.line + 1
     else
-      self.board:close()
-      self.state = 'closing'
+      self:close()
     end
   end
 

--- a/src/nodes/dealer.lua
+++ b/src/nodes/dealer.lua
@@ -29,7 +29,7 @@ function Dealer:enter(previous)
   --Dealer says "Let's play poker" after a few seconds when player enters the tavern.
   if not self.dialog then
     self.dialog = Timer.add(math.random(3,4), function()
-      poker = Dialog.new("Let's play {{yellow}}poker{{white}}.")
+      self.poker_dialog = Dialog.new("Let's play {{yellow}}poker{{white}}.")
       sound.playSfx("letsPlayPoker")
     end)
   end
@@ -38,6 +38,9 @@ end
 function Dealer:leave()
   --The timers are canceled upon leaving so the dialog and sound don't occur outside the tavern.
   Timer.cancel(self.dialog)
+  if self.poker_dialog then
+    self.poker_dialog:close()
+  end
 end
 
 function Dealer:keypressed( button, player )


### PR DESCRIPTION
Resolves #2363. I initially thought this was going to be a lot more complicated than it turned out to be. On the dealer leave function, we check to see if the dialog is open. If it is, we close it.