### PR TITLE
Allow enemies to bounce on webs

### DIFF
--- a/src/maps/valley-sandpits.tmx
+++ b/src/maps/valley-sandpits.tmx
@@ -84,7 +84,7 @@
  </layer>
  <layer name="collision" width="220" height="31">
   <data encoding="base64" compression="zlib">
-   eJzt2Q1ugkAURWG7s+5/LyZt3UA1DYmZAGXez+UNc75kEuMYRPCA4O0GALXdP7QDmJmyAXrD7OgN0KE3WKivQ0YcW9tNuY+AGdAboENvgA69ATqW3tauAX+e42Hsht4wC2tve3O9/WT1dvZ9qAuPz62RsyevI7q3I/Pe15+9XMCK3gCdM3r7es5/N79RMtAbqlH2ltlWz3oAZzmjt6PDi95QTYXrt8rLACLRG2anup/wQm9/1ra5ZXj+9/eK+gzW/95G/P9t7Tvy/lz0Pq3SW3tcyewt41qxpexu6WxElmOEddu+v9fiSG+LiH1quVeh6s07ItfPKvM8eIXOPHq+A0ceW+YVlL1lUG+vPT3HiOxzcgTvsTB6XXoeW+YVRvk9eeR9KqlyTr4KRW/R13drMnpTGXXdKq93Vare9l4bgd5y0Fusir3t3R/aMlpv7Wesit5iVerN05SyN881dvW+WvQWq1pveyr1Zl3maN9Reos1Wm/W+7lb85bzDb39P4d1I/XmQW829BZr9t48y6I33Xp4/AJ+bFpO
+   eJzt2Q1ugkAURWG7s+5/LyZt3UA1DYkhQGfez+UNc75kEuMYRPCA4O0GALXdP7QDmJmyAXrD7OgN0KE3WKivQ0Yce9tNuY+AGdAboENvgA69ATqW3rauAX+e42Hsht4wC2tvR3O9/WT1dvZ9qAuPz72RsyevI7q3lnnv689eLmBFb4DOGb19Pee/V79RMtAbqlH2ltlWz3oAZzmjt9bhRW+opsL1W+VlAJHoDbNT3U94obc/W9vcMjz/+3tFfQbrf28j/v+29R15fy56n1bpbX1cyewt41pxTdnd0tmILMcI67Z9f69FS2+LiH1quVeh6s07ItfPKvM8eIXOPHq+Ay2PLfMKyt4yqLfXkZ5jRPY5OYL3WBi9Lj2PLfMKo/yebHmfSqqck69C0Vv09d2WjN5URl23yutdlaq3o9dGoLccFX6DXUnF3o7uD+0Zrbf1Z6yK81usSr15mlL25jm+V+9rjd5iVevtSKXerMsc7TtKb7FG6816LbE3bznf0Nv/c9g2Um8e9GZDb7Fm782zLHrTrYfHL4kXX+I=
   </data>
  </layer>
  <objectgroup color="#000000" name="nodes" width="220" height="31">
@@ -476,7 +476,7 @@
     <property name="spawnType" value="keypress"/>
    </properties>
   </object>
-  <object type="bouncer" x="4104" y="528" width="192" height="48">
+  <object type="bouncer" x="4104" y="504" width="192" height="48">
    <properties>
     <property name="bval" value="1100"/>
     <property name="dbval" value="1300"/>

--- a/src/nodes/bouncer.lua
+++ b/src/nodes/bouncer.lua
@@ -17,6 +17,8 @@ function Bouncer.new(node, collider)
 end
 
 function Bouncer:collide(node, dt, mtv_x, mtv_y)
+  -- spiders shouldn't interact with bouncers
+  if node.props and node.props.name == 'spider' then return end
   
   local node_y = node.position.y + node.height
   

--- a/src/nodes/bouncer.lua
+++ b/src/nodes/bouncer.lua
@@ -17,19 +17,21 @@ function Bouncer.new(node, collider)
 end
 
 function Bouncer:collide(node, dt, mtv_x, mtv_y)
-  if not node.isPlayer then return end
-  local player = node
   
-  local player_y = player.position.y + player.character.bbox.height - player.character.bbox.y
+  local node_y = node.position.y + node.height
   
-  if player_y > self.node.y + self.node.height then
+  if node.isPlayer then
+    node_y = node.position.y + node.character.bbox.height - node.character.bbox.y
+  end
+  
+  if node_y > self.node.y + self.node.height then
     sound.playSfx('jump')
-    player.fall_damage = 0
-    player.jumping = true
+    node.fall_damage = 0
+    node.jumping = true
     if self.double_bounce then
-      player.velocity.y = self.dbval
+      node.velocity.y = self.dbval
     else
-      player.velocity.y = self.bval
+      node.velocity.y = self.bval
     end
   end
 end


### PR DESCRIPTION
fixes #2366 

This allows enemies to bounce on webs, which is pretty hilarious in the sandpits.
The bouncer class was explicitly preventing from enemies from bouncing on it so I think this may be a change we want to discuss before merging in.