### PR TITLE
Prevent popping through roof while climbing into spikes

### DIFF
--- a/src/maps/valley-sandpits-2.tmx
+++ b/src/maps/valley-sandpits-2.tmx
@@ -520,8 +520,16 @@
   <object type="killing_floor" x="773" y="209" width="18" height="39"/>
   <object type="killing_floor" x="793" y="211" width="18" height="39"/>
   <object type="killing_floor" x="816" y="96" width="1560" height="48"/>
-  <object type="climbable" x="1448" y="546" width="10" height="310"/>
-  <object type="climbable" x="750" y="229" width="11" height="243"/>
+  <object type="climbable" x="1448" y="546" width="10" height="310">
+   <properties>
+    <property name="blockTop" value="true"/>
+   </properties>
+  </object>
+  <object type="climbable" x="750" y="229" width="11" height="243">
+   <properties>
+    <property name="blockTop" value="true"/>
+   </properties>
+  </object>
   <object type="enemy" x="648" y="1080" width="48" height="48">
    <properties>
     <property name="enemytype" value="spider"/>
@@ -1220,7 +1228,11 @@
     <property name="sprite" value="sand-block-dark"/>
    </properties>
   </object>
-  <object type="climbable" x="2286" y="120" width="9" height="332"/>
+  <object type="climbable" x="2286" y="120" width="9" height="332">
+   <properties>
+    <property name="blockTop" value="true"/>
+   </properties>
+  </object>
   <object type="killing_floor" x="1824" y="558" width="44" height="21"/>
   <object type="breakable_block" x="1824" y="552" width="24" height="24">
    <properties>

--- a/src/nodes/climbable.lua
+++ b/src/nodes/climbable.lua
@@ -25,6 +25,8 @@ end
 function Climbable:collide( node, dt, mtv_x, mtv_y )
   if not node.isPlayer then return end
   local player = node
+  -- Drop the player if they take damage
+  if player.rebounding then return end
   local player_base = player.position.y + player.height
   local self_base = self.position.y + self.height
   local controls = player.controls


### PR DESCRIPTION
fixes #2362 

This currently drops the player if they collide with spikes while climbing.

 I like this as a mechanic but it would be possible to fix this bug without dropping the player in case others don't like it.