### PR TITLE
Improve item persistence

### DIFF
--- a/src/nodes/consumable.lua
+++ b/src/nodes/consumable.lua
@@ -95,7 +95,7 @@ function Consumable:update(dt, player, map)
   if not self.exists then
     return
   end
-  if self.dropping then    
+  if self.dropping then
     local nx, ny = collision.move(map, self, self.position.x, self.position.y,
                                   self.width, self.height, 
                                   self.velocity.x * dt, self.velocity.y * dt)
@@ -107,6 +107,12 @@ function Consumable:update(dt, player, map)
     -- 12 is half the size
     self.bb:moveTo(self.position.x + 12, self.position.y + 12)
   end
+
+  -- Item has finished dropping in the level
+  if not self.dropping and self.dropped and not self.saved then
+    self.containerLevel:saveAddedNode(self)
+    self.saved = true
+  end
 end
 
 function Consumable:drop(player)
@@ -116,6 +122,7 @@ function Consumable:drop(player)
   end
 
   self.dropping = true
+  self.dropped = true
 end
 
 function Consumable:floorspace_drop(player)
@@ -131,8 +138,6 @@ function Consumable:floor_pushback()
   self.dropping = false
   self.velocity.y = 0
   self.collider:setPassive(self.bb)
-
-  self.containerLevel:saveAddedNode(self)
 end
 
 return Consumable

--- a/src/nodes/material.lua
+++ b/src/nodes/material.lua
@@ -105,6 +105,12 @@ function Material:update(dt, player, map)
     
     self.bb:moveTo(self.position.x + self.width / 2 + self.bb_offset_x, self.position.y + self.height / 2)
   end
+
+  -- Item has finished dropping in the level
+  if not self.dropping and self.dropped and not self.saved then
+    self.containerLevel:saveAddedNode(self)
+    self.saved = true
+  end
 end
 
 function Material:drop(player)
@@ -114,6 +120,7 @@ function Material:drop(player)
   end
 
   self.dropping = true
+  self.dropped = true
 end
 
 function Material:floorspace_drop(player)
@@ -129,8 +136,6 @@ function Material:floor_pushback()
   self.dropping = false
   self.velocity.y = 0
   self.collider:setPassive(self.bb)
-
-  self.containerLevel:saveAddedNode(self)
 end
 
 return Material

--- a/src/nodes/projectile.lua
+++ b/src/nodes/projectile.lua
@@ -100,6 +100,7 @@ function Projectile.new(node, collider)
   -- Don't forget to pass this into hurt functions in the props file
   proj.special_damage = proj.props.special_damage or {}
   proj.solid = proj.props.solid
+  proj.dropping = false
   proj.dropped = false
 
   proj.playerCanPickUp = proj.props.playerCanPickUp
@@ -176,11 +177,17 @@ function Projectile:update(dt, player, map)
     self.position.y = ny - self.offset.y
   end
 
-  if self.dropped then
+  if self.dropping then
     self.position.x = nx
     self.position.y = ny
     -- X velocity won't need to change
     self.velocity.y = self.velocity.y + game.gravity*dt
+  end
+
+  -- Item has finished dropping in the level
+  if not self.dropping and self.dropped and not self.saved then
+    self.containerLevel:saveAddedNode(self)
+    self.saved = true
   end
 
   if self.props.update then
@@ -304,10 +311,8 @@ function Projectile:floor_pushback(tile)
 
   -- Pushback code for a dropped item
   if self.dropped then
-    self.dropped = false
+    self.dropping = false
     self.velocity.y = 0
-
-    self.containerLevel:saveAddedNode(self)
     return
   end
 
@@ -425,6 +430,7 @@ function Projectile:drop(thrower)
     self:floorspace_drop(thrower)
     return
   end
+  self.dropping = true
   self.dropped = true
 end
 

--- a/src/nodes/rangedWeapon.lua
+++ b/src/nodes/rangedWeapon.lua
@@ -87,6 +87,7 @@ function Weapon.new(node, collider, plyr, weaponItem)
   weapon.actionwalk = props.actionwalk or 'shootarrowwalk'
   weapon.actionjump = props.actionjump or 'shootarrowjump'
   weapon.dropping = false
+  weapon.dropped = false
 
   return weapon
 end
@@ -112,6 +113,12 @@ function Weapon:update(dt, player, map)
       
       self.velocity = { x = self.velocity.x,
                         y = self.velocity.y + game.gravity*dt }
+    end
+
+    -- Item has finished dropping in the level
+    if not self.dropping and self.dropped and not self.saved then
+      self.containerLevel:saveAddedNode(self)
+      self.saved = true
     end
   else
     --the weapon is being used by a player
@@ -194,6 +201,7 @@ end
 -- handles weapon being dropped in the real world
 function Weapon:drop(player)
   self.dropping = true
+  self.dropped = true
 
   self.player:setSpriteStates('default')
   self.player.currently_held = nil
@@ -229,8 +237,6 @@ function Weapon:floor_pushback()
 
   self.dropping = false
   self.velocity.y = 0
-
-  self.containerLevel:saveAddedNode(self)
 end
 
 return Weapon

--- a/src/nodes/scroll.lua
+++ b/src/nodes/scroll.lua
@@ -40,6 +40,7 @@ function Scroll.new(node, collider)
   collider:setSolid(scroll.bb)
 
   scroll.dropping = false
+  scroll.dropped = false
 
   scroll.position = { x = node.x, y = node.y }
   scroll.velocity = { x = node.x, y = node.y }
@@ -64,6 +65,12 @@ function Scroll:update(dt, player, map)
     self.velocity.y = self.velocity.y + game.gravity*dt
     
     self.bb:moveTo(self.position.x + self.width / 2, self.position.y + self.height / 2)
+  end
+
+  -- Item has finished dropping in the level
+  if not self.dropping and self.dropped and not self.saved then
+    self.containerLevel:saveAddedNode(self)
+    self.saved = true
   end
 end
 
@@ -103,6 +110,7 @@ function Scroll:drop(player)
   end
 
   self.dropping = true
+  self.dropped = true
 end
 
 function Scroll:floorspace_drop(player)
@@ -118,8 +126,6 @@ function Scroll:floor_pushback()
   self.dropping = false
   self.velocity.y = 0
   self.collider:setPassive(self.bb)
-
-  self.containerLevel:saveAddedNode(self)
 end
 
 function Scroll:wall_pushback()

--- a/src/nodes/weapon.lua
+++ b/src/nodes/weapon.lua
@@ -238,6 +238,12 @@ function Weapon:update(dt, player, map)
                  self.position.y + self.dropHeight / 2)
       end
     end
+
+    -- Item has finished dropping in the level
+    if not self.dropping and self.dropped and not self.saved then
+      self.containerLevel:saveAddedNode(self)
+      self.saved = true
+    end
   else
     --the weapon is being used by a player
     local player = self.player
@@ -369,8 +375,6 @@ function Weapon:floor_pushback()
   end
 
   self.velocity.y = 0
-
-  self.containerLevel:saveAddedNode(self)
 end
 
 return Weapon


### PR DESCRIPTION
When dropping an item into a level, wait until it has completely stopped moving before adding it to the gamesave. This means the final position of the item is saved and restored rather than just the initial floor_pushback position.

This also resolves an issue reported by @LoubiTek in the subreddit where dropping an item in a level and immediately picking it back up will cause it to respawn in that same spot if you return to that level.