### PR TITLE
Fix broken dud potions when loaded from save

### DIFF
--- a/src/playerEffects.lua
+++ b/src/playerEffects.lua
@@ -52,9 +52,13 @@ end
 
 function PlayerEffects:randEffect(player, effects)
   local rand = math.random()
-  for i,prob in ipairs(effects.p) do
-    if rand <= prob  then
-      self:doEffect(effects[i], player)
+  for i,prob in pairs(effects.p) do
+    if rand <= prob then
+      local effect = effects[i]
+      if not effect then
+        effect = effects[tostring(i)]
+      end
+      self:doEffect(effect, player)
       break
     end
   end


### PR DESCRIPTION
When potions are loaded from save, their keys are now strings rather than numbers due to the JSON encode/decode process.

So we have to check for the correct type and change it as needed. Resolves #2300.