### PR TITLE
Fix bbox offset when dropping in floorspaces

### DIFF
--- a/src/nodes/consumable.lua
+++ b/src/nodes/consumable.lua
@@ -121,6 +121,7 @@ end
 function Consumable:floorspace_drop(player)
   self.dropping = false
   self.position.y = player.footprint.y - self.height
+  self.bb:moveTo(self.position.x + 12, self.position.y + 12)
 
   self.containerLevel:saveAddedNode(self)
 end

--- a/src/nodes/material.lua
+++ b/src/nodes/material.lua
@@ -119,6 +119,7 @@ end
 function Material:floorspace_drop(player)
   self.dropping = false
   self.position.y = player.footprint.y - self.height
+  self.bb:moveTo(self.position.x + self.width / 2 + self.bb_offset_x, self.position.y + self.height / 2)
 
   self.containerLevel:saveAddedNode(self)
 end

--- a/src/nodes/scroll.lua
+++ b/src/nodes/scroll.lua
@@ -108,6 +108,7 @@ end
 function Scroll:floorspace_drop(player)
   self.dropping = false
   self.position.y = player.footprint.y - self.height
+  self.bb:moveTo(self.position.x + self.width / 2, self.position.y + self.height / 2)
 
   self.containerLevel:saveAddedNode(self)
 end


### PR DESCRIPTION
When dropping materials, consumables and scrolls in floor spaces the bounding box offset is wrong, this ensures the bounding box is directly over the items.