### PR TITLE
Key messages don't show from chests

### DIFF
--- a/src/nodes/key.lua
+++ b/src/nodes/key.lua
@@ -57,19 +57,21 @@ function Key:keypressed( button, player )
     self.containerLevel:removeNode(self)
   end
 
-  local message = self.info or {'You found the {{red}}"'..item.description..'"{{white}} key!'}
-  self.touchedPlayer.character.state = 'acquire'
+  if not self.fromChest then
+    local message = self.info or {'You found the {{red}}"'..item.description..'"{{white}} key!'}
+    player.character.state = 'acquire'
 
-  local callback = function(result)
-    self.prompt = nil
-    player.freeze = false
-    player.invulnerable = false
+    local callback = function(result)
+      self.prompt = nil
+      player.freeze = false
+      player.invulnerable = false
+    end
+    local options = {'Exit'}
+    player.freeze = true
+    player.invulnerable = true
+    self.position = { x = player.position.x + 10 ,y = player.position.y - 10 }
+    self.prompt = Prompt.new(message, callback, options, self)
   end
-  local options = {'Exit'}
-  player.freeze = true
-  player.invulnerable = true
-  self.position = { x = player.position.x + 10 ,y = player.position.y - 10 }
-  self.prompt = Prompt.new(message, callback, options, self)
 end
 
 ---

--- a/src/nodes/spawn.lua
+++ b/src/nodes/spawn.lua
@@ -122,6 +122,7 @@ function Spawn:keypressed( button, player )
       player.character.state = "acquire"
       sound.playSfx('reveal')
       local node = self:createNode()
+      node.fromChest = true
       node.delay = 0
       node.life = math.huge
       node.foreground = true


### PR DESCRIPTION
Resolves #2380.

As of right now, we don't currently have any keys that are inside chests, but proposed levels are doing that and having multiple prompts as a result.

This change only shows the chest message on keys spawning from chests.