### PR TITLE
Travis CI fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,11 @@ language: erlang
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
+install:
   - sudo apt-get install python-virtualenv lua5.1
   - sudo add-apt-repository -y ppa:bartbes/love-stable
-  - sudo apt-get update -qq
+  - sudo apt-get update -y -f
   - sudo apt-get install -y love
-install:
   - mkdir -p $TRAVIS_BUILD_DIR/share/love/
 env:
   global:

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ bin/love.app/Contents/MacOS/love:
 
 /usr/bin/love:
 	sudo add-apt-repository -y ppa:bartbes/love-stable
-	sudo apt-get update -qq
+	sudo apt-get update -y -f
 	sudo apt-get install -y love
 
 ######################################################

--- a/src/main.lua
+++ b/src/main.lua
@@ -44,7 +44,14 @@ function love.load(arg)
     error("invalid version label")
   end
 
-  if love._version ~= "0.9.1" then
+  local version = utils.split(love._version:gsub("%.", "/"),"/")
+  local major = tonumber(version[1])
+  local minor = tonumber(version[2])
+  local revision = tonumber(version[3])
+
+  if major ~= 0 or
+     minor ~= 9 or
+     revision < 1 then
     error("Love 0.9.1 is required")
   end
 


### PR DESCRIPTION
Previous "fix" wasn't quite correct. LÖVE v0.9.2 is out now and Travis uses that version which we don't allow. This change allows us to make use of versions v0.9.1 and up.

Inexplicably, Travis fails when executing code in the Makefile to install love, but succeeds when that same code is moved to .travis.yml. I'm not questioning that, this seems to work so I'm going with it.