### PR TITLE
Detach the interior castle from the throneroom

### DIFF
--- a/src/maps/castle-hawkthorne-entrance.tmx
+++ b/src/maps/castle-hawkthorne-entrance.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" width="37" height="23" tilewidth="24" tileheight="24">
+<map version="1.0" orientation="orthogonal" renderorder="right-down" width="37" height="23" tilewidth="24" tileheight="24" nextobjectid="17">
  <properties>
   <property name="blue" value="0"/>
   <property name="green" value="0"/>
@@ -56,53 +56,53 @@
    eJztzlsz1HEAxvH/cqPS7pbDvaJdEfeS7BLuK4VS7qPY7eQtkKK3EOXwFopObyGd3wIlh04zPm/BMH5jZp+Zz/XzjaLdbz0WRRtsssVv/vCXf/yP7cHJDhcviqIESY5xnDLKqaCyaP+bUj7T1HKaOuo5QwONAZpafWbI0kY7F+igk64ATT0+e+njGtfp5wY3GQjQNOIzR5673OM+D3jIaICmMZ/jPGKCxzxhkimeBmh65nOaGZ7zglnmmGchQNNLn69YZInXvOEt73gfoOmDz2U+8onPfOEr3/geoGnF5yo/+Mkav1hng80ATSXFUXSIwxyhlKPESZAs3v+mKp8nOEk1NZwiRZraAE1NPs/SzDlaOE8rGbIBmi76vMRlurnCVXropS9A0y2fgwxxmzsMM0KOfICmwgor7OBvG2e7Qs0=
   </data>
  </layer>
- <objectgroup name="floorspace" width="37" height="23">
-  <object x="0" y="336">
+ <objectgroup name="floorspace">
+  <object id="1" x="0" y="336">
    <properties>
     <property name="primary" value="true"/>
    </properties>
    <polygon points="0,0 360,0 360,24 408,24 432,24 456,24 473,-2 554,-2 540,22 584,22 600,15 707,15 696,72 648,144 600,192 552,216 328,218 292,156 -2,157 0,120 288,120 288,96 264,96 245,64 0,63"/>
   </object>
-  <object x="365" y="380">
+  <object id="2" x="365" y="380">
    <properties>
     <property name="height" value="24"/>
    </properties>
    <polygon points="1,4 47,4 63,-8 16,-8"/>
   </object>
-  <object x="96" y="377" width="72" height="6">
+  <object id="3" x="96" y="377" width="72" height="6">
    <properties>
     <property name="height" value="1000"/>
    </properties>
   </object>
-  <object x="428" y="478">
+  <object id="4" x="428" y="478">
    <properties>
     <property name="height" value="24"/>
    </properties>
    <polygon points="20,4 39,4 36,0 22,0"/>
   </object>
-  <object x="18" y="382">
+  <object id="5" x="18" y="382">
    <properties>
     <property name="height" value="24"/>
    </properties>
    <polygon points="20,4 39,4 36,0 22,0"/>
   </object>
  </objectgroup>
- <objectgroup color="#000000" name="nodes" width="37" height="23">
-  <object type="door" x="0" y="0" width="24" height="482">
+ <objectgroup color="#000000" name="nodes">
+  <object id="6" type="door" x="0" y="0" width="24" height="482">
    <properties>
     <property name="instant" value="true"/>
     <property name="level" value="seabluff"/>
     <property name="to" value="seabluff-to-castle"/>
    </properties>
   </object>
-  <object type="sprite" x="432" y="456" width="48" height="24">
+  <object id="7" type="sprite" x="432" y="456" width="48" height="24">
    <properties>
     <property name="height" value="24"/>
     <property name="sheet" value="images/sprites/castle/castle-rock.png"/>
     <property name="width" value="48"/>
    </properties>
   </object>
-  <object type="sprite" x="0" y="0" width="288" height="384">
+  <object id="8" type="sprite" x="0" y="0" width="288" height="384">
    <properties>
     <property name="depth" value="3"/>
     <property name="height" value="384"/>
@@ -110,14 +110,14 @@
     <property name="width" value="288"/>
    </properties>
   </object>
-  <object type="sprite" x="24" y="360" width="48" height="24">
+  <object id="9" type="sprite" x="24" y="360" width="48" height="24">
    <properties>
     <property name="height" value="24"/>
     <property name="sheet" value="images/sprites/castle/castle-rock.png"/>
     <property name="width" value="48"/>
    </properties>
   </object>
-  <object type="sprite" x="0" y="480" width="312" height="24">
+  <object id="10" type="sprite" x="0" y="480" width="312" height="24">
    <properties>
     <property name="height" value="24"/>
     <property name="sheet" value="images/sprites/castle/entrance_bridge.png"/>
@@ -133,7 +133,7 @@
     <property name="info" value="You unlock the castle with the {{peach}}white crystal{{white}} of discipline, which you must free from the black caverns."/>
     <property name="inventory" value="true"/>
     <property name="key" value="white_crystal"/>
-    <property name="level" value="castle-hawkthorne"/>
+    <property name="level" value="castle-hawkthorne-throne"/>
     <property name="sound" value="false"/>
     <property name="sprite" value="castle"/>
     <property name="sprite_height" value="81"/>
@@ -142,7 +142,7 @@
     <property name="trigger" value="doortriggers.pedestal"/>
    </properties>
   </object>
-  <object type="sprite" x="441" y="312" width="24" height="24">
+  <object id="12" type="sprite" x="441" y="312" width="24" height="24">
    <properties>
     <property name="animation" value="1-3,1"/>
     <property name="height" value="24"/>
@@ -150,7 +150,7 @@
     <property name="width" value="24"/>
    </properties>
   </object>
-  <object type="sprite" x="560" y="312" width="24" height="24">
+  <object id="13" type="sprite" x="560" y="312" width="24" height="24">
    <properties>
     <property name="animation" value="1-3,1"/>
     <property name="height" value="24"/>
@@ -158,9 +158,9 @@
     <property name="width" value="24"/>
    </properties>
   </object>
-  <object name="master" type="key" x="600" y="456" width="24" height="24"/>
-  <object name="main" type="door" x="48" y="432" width="24" height="50"/>
-  <object type="hiddendoortrigger" x="360" y="336" width="72" height="48">
+  <object id="14" name="master" type="key" x="600" y="456" width="24" height="24"/>
+  <object id="15" name="main" type="door" x="48" y="432" width="24" height="50"/>
+  <object id="16" type="hiddendoortrigger" x="360" y="336" width="72" height="48">
    <properties>
     <property name="height" value="52"/>
     <property name="needKey" value="white_crystal"/>

--- a/src/maps/castle-hawkthorne-throne.tmx
+++ b/src/maps/castle-hawkthorne-throne.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" width="115" height="37" tilewidth="24" tileheight="24">
+<map version="1.0" orientation="orthogonal" renderorder="right-down" width="115" height="37" tilewidth="24" tileheight="24" nextobjectid="21">
  <properties>
   <property name="blue" value="223"/>
   <property name="green" value="181"/>
@@ -49,34 +49,34 @@
    eJztmWsOgkAMBkk4iXgMz2G8/02MMUYFtrvsi68wk/RPCYV2CMtjGPK4jGm53oTOQeHcSmnVAy77g0s77wlc2nlP4NLOewKXdt4TuLTznsClnfcELu28J2I9vLbP4/4Tjw2zUZjXmV2mcBvfEaurMC9c1qmrMC9chplW7sGfqH2sGuByncnYF5f9ye3B8hiqqzAvXP4T8xiqqzAvXH6fVefPq1vqKswLl3XqKswLl3XqKszrzC7X3jWurJeS5PYQ84nL/pT0YPnEZX9Kewj5TP0W1Btc2qSsnyrgMo4Xn7hMw4PP0L0fl0s8+DwqLa5HfLYn9K+xBfhsR8q/jdpYa5NieLj+9vDoFWWfeNyOok885qPkE4/l7L1+H+W9FwDgDDwBoSImvw==
   </data>
  </layer>
- <objectgroup name="nodes" width="115" height="37" visible="0">
-  <object type="liquid" x="0" y="840" width="480" height="48">
+ <objectgroup name="nodes">
+  <object id="1" type="liquid" x="0" y="840" width="480" height="48">
    <properties>
     <property name="sprite" value="images/liquid/lava.png"/>
    </properties>
   </object>
-  <object type="liquid" x="480" y="816" width="768" height="72">
+  <object id="2" type="liquid" x="480" y="816" width="768" height="72">
    <properties>
     <property name="sprite" value="images/liquid/lava.png"/>
    </properties>
   </object>
-  <object type="liquid" x="1248" y="864" width="1176" height="24">
+  <object id="3" type="liquid" x="1248" y="864" width="1176" height="24">
    <properties>
     <property name="sprite" value="images/liquid/lava.png"/>
    </properties>
   </object>
-  <object type="liquid" x="2424" y="840" width="336" height="48">
+  <object id="4" type="liquid" x="2424" y="840" width="336" height="48">
    <properties>
     <property name="sprite" value="images/liquid/lava.png"/>
    </properties>
   </object>
-  <object name="main" type="door" x="35" y="132" width="51" height="84">
+  <object id="5" name="main" type="door" x="35" y="132" width="51" height="84">
    <properties>
-    <property name="level" value="castle-hawkthorne"/>
+    <property name="level" value="castle-hawkthorne-entrance"/>
     <property name="to" value="next"/>
    </properties>
   </object>
-  <object type="sprite" x="288" y="192" width="24" height="24">
+  <object id="6" type="sprite" x="288" y="192" width="24" height="24">
    <properties>
     <property name="animation" value="1-3,1"/>
     <property name="height" value="24"/>
@@ -84,7 +84,7 @@
     <property name="width" value="24"/>
    </properties>
   </object>
-  <object type="sprite" x="0" y="360" width="24" height="24">
+  <object id="7" type="sprite" x="0" y="360" width="24" height="24">
    <properties>
     <property name="animation" value="1-3,1"/>
     <property name="height" value="24"/>
@@ -92,7 +92,7 @@
     <property name="width" value="24"/>
    </properties>
   </object>
-  <object type="sprite" x="2376" y="600" width="24" height="24">
+  <object id="8" type="sprite" x="2376" y="600" width="24" height="24">
    <properties>
     <property name="animation" value="1-3,1"/>
     <property name="height" value="24"/>
@@ -100,7 +100,7 @@
     <property name="width" value="24"/>
    </properties>
   </object>
-  <object type="sprite" x="2328" y="648" width="24" height="24">
+  <object id="9" type="sprite" x="2328" y="648" width="24" height="24">
    <properties>
     <property name="animation" value="1-3,1"/>
     <property name="height" value="24"/>
@@ -108,7 +108,7 @@
     <property name="width" value="24"/>
    </properties>
   </object>
-  <object type="sprite" x="2280" y="696" width="24" height="24">
+  <object id="10" type="sprite" x="2280" y="696" width="24" height="24">
    <properties>
     <property name="animation" value="1-3,1"/>
     <property name="height" value="24"/>
@@ -116,13 +116,13 @@
     <property name="width" value="24"/>
    </properties>
   </object>
-  <object name="greendale" type="key" x="2496" y="624" width="24" height="24"/>
-  <object type="scenetrigger" x="2472" y="504" width="24" height="144">
+  <object id="11" name="greendale" type="key" x="2496" y="624" width="24" height="24"/>
+  <object id="12" type="scenetrigger" x="2472" y="504" width="24" height="144">
    <properties>
     <property name="cutscene" value="throne"/>
    </properties>
   </object>
-  <object type="sprite" x="2448" y="768" width="24" height="24">
+  <object id="13" type="sprite" x="2448" y="768" width="24" height="24">
    <properties>
     <property name="animation" value="1-2,1"/>
     <property name="height" value="24"/>
@@ -130,7 +130,7 @@
     <property name="width" value="24"/>
    </properties>
   </object>
-  <object type="sprite" x="2496" y="720" width="24" height="24">
+  <object id="14" type="sprite" x="2496" y="720" width="24" height="24">
    <properties>
     <property name="animation" value="1-2,1"/>
     <property name="height" value="24"/>
@@ -138,7 +138,7 @@
     <property name="width" value="24"/>
    </properties>
   </object>
-  <object type="sprite" x="2496" y="744" width="24" height="24">
+  <object id="15" type="sprite" x="2496" y="744" width="24" height="24">
    <properties>
     <property name="animation" value="1-2,1"/>
     <property name="height" value="24"/>
@@ -146,7 +146,7 @@
     <property name="width" value="24"/>
    </properties>
   </object>
-  <object type="sprite" x="2496" y="768" width="24" height="24">
+  <object id="16" type="sprite" x="2496" y="768" width="24" height="24">
    <properties>
     <property name="animation" value="1-2,1"/>
     <property name="height" value="24"/>
@@ -154,7 +154,7 @@
     <property name="width" value="24"/>
    </properties>
   </object>
-  <object type="sprite" x="2496" y="792" width="24" height="24">
+  <object id="17" type="sprite" x="2496" y="792" width="24" height="24">
    <properties>
     <property name="animation" value="1-2,1"/>
     <property name="height" value="24"/>
@@ -162,7 +162,7 @@
     <property name="width" value="24"/>
    </properties>
   </object>
-  <object type="sprite" x="2496" y="816" width="24" height="24">
+  <object id="18" type="sprite" x="2496" y="816" width="24" height="24">
    <properties>
     <property name="animation" value="1-2,1"/>
     <property name="height" value="24"/>
@@ -170,7 +170,7 @@
     <property name="width" value="24"/>
    </properties>
   </object>
-  <object type="sprite" x="2448" y="792" width="24" height="24">
+  <object id="19" type="sprite" x="2448" y="792" width="24" height="24">
    <properties>
     <property name="animation" value="1-2,1"/>
     <property name="height" value="24"/>
@@ -178,7 +178,7 @@
     <property name="width" value="24"/>
    </properties>
   </object>
-  <object type="sprite" x="2448" y="816" width="24" height="24">
+  <object id="20" type="sprite" x="2448" y="816" width="24" height="24">
    <properties>
     <property name="animation" value="1-2,1"/>
     <property name="height" value="24"/>


### PR DESCRIPTION
This detaches the interior rooms of castle hawkthorne from the throneroom.  Right now there's not much going on in those rooms.  All they contain are semi working vehicles and empty rooms.  In the future this should be much more complicated so for the V1.0 release I've connected the entrance to the throneroom.