### PR TITLE
Prevent player from falling through moving platforms (Hopefully)

### DIFF
--- a/src/hawk/collision.lua
+++ b/src/hawk/collision.lua
@@ -392,7 +392,7 @@ function module.move_y(map, player, x, y, width, height, dx, dy)
   -- Scan through all moving platforms
   for _, platform in ipairs(map.moving_platforms) do
     if x + width >= platform.x and x <= platform.x + platform.width then
-      local foot = y + height
+      local foot = y + height - 2
       local above_tile = foot <= platform.y
       
       if above_tile and platform.y <= (new_y + height + 2) and


### PR DESCRIPTION
This should fix the [issue pointed out in the subreddit](http://www.reddit.com/r/hawkthorne/comments/379mgq/still_falling_through_platforms_in_village_forest/).

I seems that some people were still having trouble with vertically moving platforms, I was never able to reproduce this but I do fall through when standing up from a crouch while the platform is moving up, this fixes that issue for me and should fix the issue pointed out in the above post.