### PR TITLE
Enable item pickup sounds

### DIFF
--- a/src/inventory.lua
+++ b/src/inventory.lua
@@ -705,7 +705,7 @@ function Inventory:addItem(item, sfx, callback)
   end 
   local slot = self:nextAvailableSlot(pageName)
   if not slot then
-    if sfx ~= false then 
+    if sfx ~= false then
       sound.playSfx('dbl_beep')
     end
     return false

--- a/src/nodes/consumable.lua
+++ b/src/nodes/consumable.lua
@@ -68,7 +68,7 @@ function Consumable:keypressed( button, player )
     self.containerLevel:removeNode(self)
     self.collider:remove(self.bb)
   end
-  player.inventory:addItem(item, false, callback)
+  player.inventory:addItem(item, true, callback)
 end
 
 ---

--- a/src/nodes/material.lua
+++ b/src/nodes/material.lua
@@ -66,7 +66,7 @@ function Material:keypressed( button, player )
     self.containerLevel:removeNode(self)
     self.collider:remove(self.bb)
   end
-  player.inventory:addItem(item, false, callback)
+  player.inventory:addItem(item, true, callback)
 end
 
 ---

--- a/src/nodes/projectile.lua
+++ b/src/nodes/projectile.lua
@@ -224,7 +224,7 @@ function Projectile:keypressed( button, player)
         item:select(player)
       end
     end
-    player.inventory:addItem(item, false, callback)
+    player.inventory:addItem(item, true, callback)
   end
 end
 

--- a/src/nodes/rangedWeapon.lua
+++ b/src/nodes/rangedWeapon.lua
@@ -167,7 +167,7 @@ function Weapon:keypressed( button, player)
         item:select(player)
       end
     end
-    player.inventory:addItem(item, false, callback)
+    player.inventory:addItem(item, true, callback)
   end
 end
 

--- a/src/nodes/scroll.lua
+++ b/src/nodes/scroll.lua
@@ -93,7 +93,7 @@ function Scroll:keypressed( button, player)
         item:select(player)
       end
     end
-    player.inventory:addItem(item, false, callback)
+    player.inventory:addItem(item, true, callback)
   end
 end
 

--- a/src/nodes/weapon.lua
+++ b/src/nodes/weapon.lua
@@ -305,7 +305,7 @@ function Weapon:keypressed( button, player)
         item:select(player)
       end
     end
-    player.inventory:addItem(item, false, callback)
+    player.inventory:addItem(item, true, callback)
   end
 end
 


### PR DESCRIPTION
No idea why the sound was disabled in the first place, but this will definitely help with audible feedback for players and give an error sound for when inventory is full and pickup fails.