### PR TITLE
Ladder in town improvement

### DIFF
--- a/src/maps/town.tmx
+++ b/src/maps/town.tmx
@@ -107,7 +107,7 @@
     <property name="to" value="main"/>
    </properties>
   </object>
-  <object type="climbable" x="560" y="165" width="11" height="100"/>
+  <object type="climbable" x="567" y="165" width="1" height="100"/>
   <object name="rock" type="material" x="1776" y="240" width="24" height="24"/>
   <object type="door" x="0" y="0" width="24" height="264">
    <properties>


### PR DESCRIPTION
Player can no longer get stuck in release/grab loop by helding UP and LEFT. Resolves. #2384.

This is a cheap and easy solution that appears to work for me. I just make the ladder width much narrower which gives the player enough room on the left side of the ladder to keep walking left without starting to fall and then re-grab the ladder.

This could also be fixed by extending the platform to the left a little more, but then there's a spot that the player can stand on which appears to be hovering in mid-air.

If this breaks for someone else, I vote that we just close the issue.