### PR TITLE
Controller module enabled for releases

### DIFF
--- a/templates/conf.lua
+++ b/templates/conf.lua
@@ -2,13 +2,13 @@ function love.conf(t)
     t.title             = "Journey to the Center of Hawkthorne v{{ version }}"
     t.url               = "http://projecthawkthorne.com"
     t.author            = "https://github.com/hawkthorne?tab=members"
-    t.version           = "0.9.0"
+    t.version           = "0.9.1"
     t.identity          = "hawkthorne_release"
     t.window.width      = 1056
     t.window.height     = 672
     t.window.fullscreen = false
     t.console           = false
     t.modules.physics   = false
-    t.modules.joystick  = false
+    t.modules.joystick  = true
     t.release           = true
 end


### PR DESCRIPTION
Our build process uses a different `conf.lua` template that had the joystick module disabled for releases. That explains our issue, #2400.