### PR TITLE
Autosave all levels

### DIFF
--- a/src/hud.lua
+++ b/src/hud.lua
@@ -143,7 +143,7 @@ function HUD:draw( player )
   love.graphics.setColor( 255, 255, 255, 255 )
 
   if self.saving then
-    self.savingAnimation:draw(savingImage, self.x + 120 + 5, self.y + 12)
+    self.savingAnimation:draw(savingImage, self.x + camera:getWidth() - 60, self.y)
   end
 
   fonts.revert()

--- a/src/maps/abed-castle-interior.tmx
+++ b/src/maps/abed-castle-interior.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="53" height="16" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="offset" value="2"/>
   <property name="overworldName" value="town_2"/>
   <property name="soundtrack" value="abeds-castle"/>

--- a/src/maps/abed-cave.tmx
+++ b/src/maps/abed-cave.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="60" height="20" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="offset" value="5"/>
   <property name="overworldName" value="town_2"/>
   <property name="soundtrack" value="abeds-castle"/>

--- a/src/maps/acschool.tmx
+++ b/src/maps/acschool.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="33" height="14" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
  </properties>
  <tileset firstgid="1" name="acschool" tilewidth="24" tileheight="24">
   <image source="../images/tilesets/acschool.png" width="264" height="240"/>

--- a/src/maps/admin-hallway.tmx
+++ b/src/maps/admin-hallway.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="48" height="14" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="blue" value="159"/>
   <property name="green" value="123"/>
   <property name="red" value="104"/>

--- a/src/maps/baseball.tmx
+++ b/src/maps/baseball.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="22" height="14" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="blue" value="249"/>
   <property name="green" value="154"/>
   <property name="offset" value="0"/>

--- a/src/maps/blacksmith.tmx
+++ b/src/maps/blacksmith.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="24" height="14" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="overworldName" value="town_1"/>
   <property name="soundtrack" value="blacksmith"/>
  </properties>

--- a/src/maps/borchert-hallway.tmx
+++ b/src/maps/borchert-hallway.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="39" height="14" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="blue" value="159"/>
   <property name="green" value="123"/>
   <property name="red" value="104"/>

--- a/src/maps/castle-hawkthorne-room-1.tmx
+++ b/src/maps/castle-hawkthorne-room-1.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="100" height="14" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="blue" value="0"/>
   <property name="green" value="0"/>
   <property name="offset" value="0"/>

--- a/src/maps/castle-hawkthorne-room-2.tmx
+++ b/src/maps/castle-hawkthorne-room-2.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="100" height="14" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="blue" value="0"/>
   <property name="green" value="0"/>
   <property name="offset" value="0"/>

--- a/src/maps/castle-hawkthorne-room-3.tmx
+++ b/src/maps/castle-hawkthorne-room-3.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="100" height="14" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="blue" value="0"/>
   <property name="green" value="0"/>
   <property name="offset" value="0"/>

--- a/src/maps/castle-hawkthorne-room-4.tmx
+++ b/src/maps/castle-hawkthorne-room-4.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="100" height="14" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="blue" value="0"/>
   <property name="green" value="0"/>
   <property name="offset" value="0"/>

--- a/src/maps/class-basement.tmx
+++ b/src/maps/class-basement.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="72" height="14" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="blue" value="115"/>
   <property name="green" value="109"/>
   <property name="red" value="105"/>

--- a/src/maps/class-hallway-2.tmx
+++ b/src/maps/class-hallway-2.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="92" height="14" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="blue" value="159"/>
   <property name="green" value="123"/>
   <property name="red" value="104"/>

--- a/src/maps/class-hallway.tmx
+++ b/src/maps/class-hallway.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="92" height="14" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="blue" value="153"/>
   <property name="green" value="195"/>
   <property name="red" value="219"/>

--- a/src/maps/deans-closet2.tmx
+++ b/src/maps/deans-closet2.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="30" height="15" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="blue" value="117"/>
   <property name="green" value="117"/>
   <property name="offset" value="1"/>

--- a/src/maps/deans-office-2.tmx
+++ b/src/maps/deans-office-2.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="22" height="14" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="blue" value="83"/>
   <property name="green" value="148"/>
   <property name="jumping" value="false"/>

--- a/src/maps/deans-office.tmx
+++ b/src/maps/deans-office.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="22" height="14" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="blue" value="83"/>
   <property name="green" value="148"/>
   <property name="jumping" value="false"/>

--- a/src/maps/dorm-lobby.tmx
+++ b/src/maps/dorm-lobby.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="35" height="14" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="blue" value="88"/>
   <property name="green" value="113"/>
   <property name="red" value="168"/>

--- a/src/maps/gazette-office-2.tmx
+++ b/src/maps/gazette-office-2.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="22" height="14" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="blue" value="92"/>
   <property name="green" value="114"/>
   <property name="jumping" value="false"/>

--- a/src/maps/gazette-office.tmx
+++ b/src/maps/gazette-office.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="36" height="14" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="blue" value="128"/>
   <property name="green" value="115"/>
   <property name="jumping" value="false"/>

--- a/src/maps/greendale-anthropology.tmx
+++ b/src/maps/greendale-anthropology.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="37" height="14" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="soundtrack" value="greendale-alt"/>
  </properties>
  <tileset firstgid="1" name="anthropologyroom" tilewidth="24" tileheight="24">

--- a/src/maps/greendale-biology.tmx
+++ b/src/maps/greendale-biology.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="40" height="15" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="soundtrack" value="greendale-alt"/>
  </properties>
  <tileset firstgid="1" name="greendale-classrooms" tilewidth="24" tileheight="24">

--- a/src/maps/greendale-englishmemorial.tmx
+++ b/src/maps/greendale-englishmemorial.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="33" height="15" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="blue" value="249"/>
   <property name="green" value="154"/>
   <property name="offset" value="1"/>

--- a/src/maps/greendale-fry.tmx
+++ b/src/maps/greendale-fry.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="22" height="14" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="soundtrack" value="greendale-alt"/>
  </properties>
  <tileset firstgid="1" name="greendale-classrooms" tilewidth="24" tileheight="24">

--- a/src/maps/greendale-ladders.tmx
+++ b/src/maps/greendale-ladders.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="22" height="14" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="soundtrack" value="greendale-alt"/>
  </properties>
  <tileset firstgid="1" name="greendale-classrooms" tilewidth="24" tileheight="24">

--- a/src/maps/house.tmx
+++ b/src/maps/house.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="22" height="14" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="jumping" value="false"/>
   <property name="overworldName" value="town_1"/>
   <property name="soundtrack" value="tavern"/>

--- a/src/maps/lab.tmx
+++ b/src/maps/lab.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="22" height="14" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="jumping" value="false"/>
   <property name="overworldName" value="town_1"/>
   <property name="soundtrack" value="potionlab"/>

--- a/src/maps/mens-bathroom.tmx
+++ b/src/maps/mens-bathroom.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="22" height="14" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="soundtrack" value="greendale-alt"/>
  </properties>
  <tileset firstgid="1" name="bathroom" tilewidth="24" tileheight="24">

--- a/src/maps/parking-lot.tmx
+++ b/src/maps/parking-lot.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="47" height="18" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="blue" value="249"/>
   <property name="floor" value="12"/>
   <property name="green" value="154"/>

--- a/src/maps/potteryclass.tmx
+++ b/src/maps/potteryclass.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="32" height="14" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="soundtrack" value="greendale-alt"/>
  </properties>
  <tileset firstgid="1" name="pottery" tilewidth="24" tileheight="24">

--- a/src/maps/rainbow-bar.tmx
+++ b/src/maps/rainbow-bar.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="45" height="14" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="blue" value="153"/>
   <property name="green" value="195"/>
   <property name="overworldName" value="island_2"/>

--- a/src/maps/rave-hallway.tmx
+++ b/src/maps/rave-hallway.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="48" height="14" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="blue" value="47"/>
   <property name="green" value="37"/>
   <property name="red" value="31"/>

--- a/src/maps/secretwritersgarden.tmx
+++ b/src/maps/secretwritersgarden.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="25" height="14" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="soundtrack" value="lovesoalike"/>
  </properties>
  <tileset firstgid="1" name="secretgarden" tilewidth="24" tileheight="24">

--- a/src/maps/sophieb.tmx
+++ b/src/maps/sophieb.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="46" height="14" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="soundtrack" value="asilaymedown"/>
  </properties>
  <tileset firstgid="1" name="sophiedance" tilewidth="24" tileheight="24">

--- a/src/maps/sunchamber.tmx
+++ b/src/maps/sunchamber.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="22" height="14" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
  </properties>
  <tileset firstgid="1" name="sunchamber" tilewidth="24" tileheight="24">
   <image source="../images/tilesets/sunchamber.png" width="288" height="192"/>

--- a/src/maps/tavern.tmx
+++ b/src/maps/tavern.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="22" height="14" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="overworldName" value="town_1"/>
   <property name="soundtrack" value="tavern"/>
  </properties>

--- a/src/maps/trampoline.tmx
+++ b/src/maps/trampoline.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="22" height="33" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="blue" value="249"/>
   <property name="green" value="154"/>
   <property name="offset" value="18"/>

--- a/src/maps/womens-bathroom.tmx
+++ b/src/maps/womens-bathroom.tmx
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map version="1.0" orientation="orthogonal" width="22" height="14" tilewidth="24" tileheight="24">
  <properties>
-  <property name="autosave" value="false"/>
   <property name="soundtrack" value="greendale-alt"/>
  </properties>
  <tileset firstgid="1" name="bathroom" tilewidth="24" tileheight="24">

--- a/src/nodes/savepoint.lua
+++ b/src/nodes/savepoint.lua
@@ -40,7 +40,9 @@ end
 
 function Savepoint:collide(node)
   if node.isPlayer and not self.visited then
+    self.level.hud:startSave()
     save:saveGame(self.level, self.name)
+    self.level.hud:endSave()
     self.visited = true
   end
 end

--- a/src/quest.lua
+++ b/src/quest.lua
@@ -60,8 +60,11 @@ function Quest:activate(npc, player, quest, condition)
 end
 
 function Quest:save(quest)
+  local level = Gamestate.currentState()
+  level.hud:startSave()
   local gamesave = app.gamesaves:active()
   gamesave:set( 'quest', json.encode( quest ) )
+  level.hud:endSave()
 end
 
 function Quest:load(player)

--- a/src/save.lua
+++ b/src/save.lua
@@ -6,12 +6,10 @@ function save:saveGame(_level, _door)
   local gamesave = app.gamesaves:active()
   local point = gamesave:get('savepoint')
   if point ~= null and (_level.name == point.level and _door == point.name) or app.config.hardcore then return end
-  _level.hud:startSave()
   gamesave:set('savepoint', {level=_level.name, name=_door})
   local player = _level.player
   player:saveData(gamesave)
   gamesave:flush()
-  _level.hud:endSave()
 end
 
 return save


### PR DESCRIPTION
Resolves #2416.

No longer show save animation when changing levels because it is implied.

Added the save animation when a new quest is saved. Moved the save animation to the top right corner of the screen.