### PR TITLE
NPCs close their menus when they become busy

### DIFF
--- a/src/nodes/npc.lua
+++ b/src/nodes/npc.lua
@@ -471,6 +471,7 @@ end
 function NPC:update(dt, player)
   if self.state == 'hidden' then return end
   if self.menu.state ~= "closed" then self.menu:update(dt) end
+  if self.menu.state ~= "closed" and self.busy then self.menu:close(player) end
   self:animation():update(dt)
   self:handleSounds(dt)
 


### PR DESCRIPTION
Interact with Hilda just before she notices the burning building and her menu will stay open.

This change, closes any NPC menu if they are busy.