### PR TITLE
Up projectile stacking limit.

### DIFF
--- a/src/items/weapons/arrow.lua
+++ b/src/items/weapons/arrow.lua
@@ -6,7 +6,7 @@ return{
   damage = 2,
   special_damage = 'stab= 1',
   info = 'a set of 5 arrows',
-  MAX_ITEMS = 40,
+  MAX_ITEMS = 99,
   quantity = 5,
   directory = 'weapons/',
 }

--- a/src/items/weapons/icicle.lua
+++ b/src/items/weapons/icicle.lua
@@ -12,7 +12,7 @@ return{
   damage = '2',
   special_damage = 'stab= 1',
   info = 'a set of 5 very sharp icicles',
-  MAX_ITEMS = 10,
+  MAX_ITEMS = 99,
   quantity = 5,
   directory = 'weapons/',
 }

--- a/src/items/weapons/throwingaxe.lua
+++ b/src/items/weapons/throwingaxe.lua
@@ -11,7 +11,7 @@ return{
   damage = '2',
   special_damage = 'slash= 1',
   info = 'a set of 4 throwing axes',
-  MAX_ITEMS = 12,
+  MAX_ITEMS = 99,
   quantity = 4,
   directory = 'weapons/',
 }

--- a/src/items/weapons/throwingknife.lua
+++ b/src/items/weapons/throwingknife.lua
@@ -11,7 +11,7 @@ return{
   damage = '1',
   special_damage = 'stab= 1',
   info = 'a set of 5 throwing knives',
-  MAX_ITEMS = 15,
+  MAX_ITEMS = 99,
   quantity = 5,
   directory = 'weapons/',
 }


### PR DESCRIPTION
This increases the amount that projectiles can stack in the inventory.  Originally this number was low to prevent stocking the inventory and to forced the player to switch between stacks of projectiles.  Since opening the inventory pauses enemies it's only annoying to switch between small stacks of projectiles. 