### PR TITLE
Prevent player from "healing" when hurt

### DIFF
--- a/src/player.lua
+++ b/src/player.lua
@@ -632,7 +632,8 @@ function Player:hurt(damage)
   --Apply defense as a percentage of player health
   damage = (damage - self.protection) * (1 - self.defense / 100)
 
-  damage = math.floor(damage)
+  -- Verify that damage >= 0 and an integer
+  damage = math.floor(math.max(damage, 0))
 
   sound.playSfx( "damage" )
   self.rebounding = true


### PR DESCRIPTION
Currently there are particular cases where while wearing armor the player will take negative damage effectively healing them by a small amount. This pull guarantees that the smallest damage taken is 0.