### PR TITLE
Remove questbadge from HUD

### DIFF
--- a/src/hud.lua
+++ b/src/hud.lua
@@ -63,34 +63,6 @@ function HUD:update(dt)
     end
 end
 
--- Draw the quest badge in HUD
--- @param player the player
--- @return nil
-function HUD:questBadge( player )
-    local quest = player.quest
-    local questParent = player.questParent
-
-    local width = (love.graphics.getFont():getWidth( quest ) * 0.5) + 4
-    local height = 24
-    local margin = 20
-
-    local x = camera.x + 125
-    local y = camera.y + 23
-
-    -- Draw rectangle
-    love.graphics.setColor( 0, 0, 0, 180 )
-    love.graphics.rectangle('fill', x, y, width, height)
-
-    -- Draw text
-    love.graphics.setColor( 255, 255, 255, 255 )
-    love.graphics.print(quest, (x + 2), (y + 2), 0, 0.5, 0.5)
-    love.graphics.push()
-    love.graphics.printf("for " .. questParent, (x + 2), (y + 15), (width + 8), "left", 0, 0.5, 0.5)
-    love.graphics.pop()
-
-    love.graphics.setColor( 255, 255, 255, 255 )
-end
-
 function HUD:draw( player )
   if not window.dressing_visible then
     return
@@ -134,10 +106,6 @@ function HUD:draw( player )
     for i,effect in ipairs(player.activeEffects) do
       love.graphics.printf(effect, self.x + 20, self.y + 40 + (20 * i), 350, "left",0,0.5,0.5)
     end
-  end
-
-  if player.quest ~= nil then
-    self:questBadge( player )
   end
 
   love.graphics.setColor( 255, 255, 255, 255 )


### PR DESCRIPTION
Since we have questitems in the inventory now this pull removes the ugly questbadge from the HUD.  I'm not sure if we should merge this in before the new HUD design since without the questbadge there's no indication in the HUD that the player is on a quest.  I don't think it's a big deal but that's up for debate.