### PR TITLE
Sometimes level.map mysteriously doesn't exist???

### DIFF
--- a/src/player.lua
+++ b/src/player.lua
@@ -372,6 +372,7 @@ end
 -- @param dt The time delta
 -- @return nil
 function Player:update(dt, map)
+  if not map then return end -- because something is horribly wrong that shouldn't ever happen
   self.inventory:update( dt )
   self.attack_box:update()
 


### PR DESCRIPTION
#2461 makes no sense. There are some cases where the `map` property doesn't get properly passed from `level.lua` to `player.lua`. This should never happen and I can't explain why it happens. I blame LÖVE.