### PR TITLE
Player attack node no longer collides with bouncer

### DIFF
--- a/src/nodes/bouncer.lua
+++ b/src/nodes/bouncer.lua
@@ -17,9 +17,11 @@ function Bouncer.new(node, collider)
 end
 
 function Bouncer:collide(node, dt, mtv_x, mtv_y)
+  if node.playerAttack then return end -- player attack will cause a crash and can't bounce anyways
+
   -- spiders shouldn't interact with bouncers
   if node.props and node.props.name == 'spider' then return end
-  
+
   local node_y = node.position.y + node.height
   
   if node.isPlayer then


### PR DESCRIPTION
Resolves #2463 where it was discovered that the player attack node attempts to collide with the bouncer node and because it has some non-standard attributes, compared to most other nodes, it crashes the game.

No need to have it interact with the bouncers anyways, so now it doesn't.