### PR TITLE
The Epic's water spout dies hitting a wall

### DIFF
--- a/src/nodes/projectiles/waterSpout.lua
+++ b/src/nodes/projectiles/waterSpout.lua
@@ -121,6 +121,7 @@ return{
         end)
       else
         node:hurt(projectile.damage, projectile.special_damage, 0)
+        projectile:die()
       end
     end
     if node.isFire and node.die then


### PR DESCRIPTION
Resolves the important parts of #2470. I'm not going to touch the fact that you can shoot a water spout while you're jumping or otherwise in the air because that will mean modifying too many other core components of the game.