### PR TITLE
Player still dropping through moving platforms

### DIFF
--- a/src/hawk/collision.lua
+++ b/src/hawk/collision.lua
@@ -394,12 +394,16 @@ function module.move_y(map, player, x, y, width, height, dx, dy)
   -- Scan through all moving platforms
   for _, platform in ipairs(map.moving_platforms) do
     if x + width >= platform.x and x <= platform.x + platform.width then
-      local foot = y + height - 2
+      -- Only apply platform dy when the platform is moving up
+      local foot = y + height - 2 + math.min(0, platform.dy)
       local above_tile = foot <= platform.y
       
       if above_tile and platform.y <= (new_y + height + 2) and
          direction == 'down' then
-          
+        
+        -- Dropping is not allowed on moving platforms
+        player.platform_dropping = false
+        
         if player.floor_pushback then
           player:floor_pushback()
         end

--- a/src/nodes/movingplatform.lua
+++ b/src/nodes/movingplatform.lua
@@ -67,6 +67,8 @@ function MovingPlatform.new(node, collider, level)
   mp.offset_x = node.properties.offset_x and node.properties.offset_x or 0
   mp.offset_y = node.properties.offset_y and node.properties.offset_y or 0
   mp.speed = node.properties.speed and node.properties.speed or 1
+  mp.dx = 0
+  mp.dy = 0
   mp.pos = node.properties.start and tonumber(node.properties.start) or 0.5 -- middle
   mp.showline = node.properties.showline == 'true'
   mp.moving = node.properties.touchstart ~= 'true'
@@ -190,7 +192,11 @@ function MovingPlatform:update(dt,player)
     self.x, self.y = x, p.y - (self.height / 2)
   else
     local p = self.bspline:eval( self.pos )
+    local ox = self.x
+    local oy = self.y
     self.x, self.y = p.x - (self.width / 2), p.y - (self.height / 2)
+    self.dx = self.x - ox
+    self.dy = self.y - oy
   end
   
   if self.animation then


### PR DESCRIPTION
I think this is the second or third time I've fixed this bug, this time I'm fairly certain we've got it this time.
Before this bug was fixed, but with the addition of some faster platforms in the recent village-forest upgrade this issue has come back, We now take the platforms dy value into consideration when placing the player on one so this should continue working even if we add faster platforms.

I also fixed a bug where if the player attempted to drop while on a moving platform and then jumped onto a one-way they would fall through as if they had dropped.

A good place to test either of these issues is village-forest.