### PR TITLE
Don't push player through ceiling in black-caverns

### DIFF
--- a/src/maps/black-caverns.tmx
+++ b/src/maps/black-caverns.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="170" height="90" tilewidth="24" tileheight="24" nextobjectid="310">
+<map version="1.0" orientation="orthogonal" width="170" height="90" tilewidth="24" tileheight="24">
  <properties>
   <property name="offset" value="76"/>
   <property name="overworldName" value="caverns"/>
@@ -34,55 +34,55 @@
    eJztnEFy20AMBJ3/v8Pv8Dvym5QPOoTF5QIEFjPYna7CJRIpYNCmJMfS95+vr2+VSnVUMcOSDbqPU2s35OmZe++GPJWnJyBPxQ6g/ZKnwgLaLzkqLKAdk6dj0DlUPvbsvGjH5OkYdA7y9AzP3oLeB1MxZCLuQbvBVAyZiP9BO8FYyGzEPWgnWHbL4KkY0yn76v3KUzwdM5On59ExK3nq77UrnX+mV/Z8dz55ikOezs89ezw2T7vu8wl56ju3PF1P9XPPajJ7RjsZnWOHfX6Qp/ZzMNSKOTogT+3nYKqK3jOyQmaO4CeY25tjmKtilkjep3o6mmd2e9VO0a6i9ozOYHdPfwhyZPe0eyG59nJ9PeDpFZ2jPD3HU+/tT/ftVr98fk7RvTDWWy8ymD2epZ9ddvs0t8q261WMHmfUj+dc3WqnWVD5RNzwHGf1WJ6eVzt4usv7/V1ew6DyqfJU7/f3mAWVT5WnT/ebgc6xYg9dqztRT9H5y9NaT63/357NaJ671yGW49lqdU6ihln+T7d1eO9UlZNYSzR/tIcIT0/h9zp0reg53iJP/XOKeiJ7/UvgoTyNc3fdzLoOzh7Diq6n/jlFPfLUP+cOoPdSvXN0TxFPR/e5/vv19xozrs9plT9PVtB7kad+Ty3HRpxi8hS9D3k673n2twtRT0fvC+SpPI3s33qs93m/W0bIHbzhVE+92YyIXE93rmzkqS0bL+gM0JWNPL1Hz/vytIOn1zm9oDNAVzby1JaNF3QG6MrmVE9X/04enQG6sjnVU+882bnuXtnIU3m6cgezv5eKfofk7p6u/swPOgN0veHp7/5O8vTHcJ8s0BmgqzpP1h1E510NOh90VefJuoPovHre59zP2zxZdxCddzXofFB5e+5v+ezLp07yNPqZbg/ofDp4mpnnm2OYcsvsvepxGCsLzzX01OtptPeqx2EsNPJUnspTrkw7fOcQa7F7wN6ftecuvbMWe5bs/Vl77tI7a7Fnyd7fXaG+rzMbdI4jDxi/J549P2vPHUHn2MkD9v7kqTzo0J88rc3U+zmIbjuv7Hm316esoN3s7ukusM+DdnPlzjv2jIJ1ni7v9yN07BkF+zxoNyt2vrLnld/lXYk83dvTJyp8zcpOnuI9XTmrhxXXW28f6B2MuMsF7SPKYda+Mmfy3t9zvOe4t7d5emWsDNAzrJgN3TtbPuheM1xF9y9P5WmXGdiz6Q56Dxl7QffMlsddNt1B7+F0T1cjT3l2iO6zu6eIvryg9yRP43NajvGelw30nk731DNvpacZP1eZoHeTkQu6R3RZssnKDwU6Y3mqUqlU/esfqEuuDQ==
   </data>
  </layer>
- <objectgroup color="#f9f9ff" name="nodes">
-  <object id="1" type="climbable" x="248" y="1078" width="8" height="188"/>
-  <object id="2" name="main" type="door" x="48" y="1488" width="24" height="48">
+ <objectgroup color="#f9f9ff" name="nodes" width="0" height="0">
+  <object type="climbable" x="248" y="1078" width="8" height="188"/>
+  <object name="main" type="door" x="48" y="1488" width="24" height="48">
    <properties>
     <property name="level" value="gay-island-4"/>
     <property name="sound" value="false"/>
     <property name="to" value="ferry"/>
    </properties>
   </object>
-  <object id="3" type="bouncer" x="696" y="1440" width="264" height="48">
+  <object type="bouncer" x="696" y="1440" width="264" height="48">
    <properties>
     <property name="dbval" value="1420"/>
    </properties>
   </object>
-  <object id="4" type="climbable" x="656" y="1609" width="7" height="265">
+  <object type="climbable" x="656" y="1609" width="7" height="265">
    <properties>
     <property name="blockTop" value="true"/>
    </properties>
   </object>
-  <object id="5" type="killing_floor" x="1176" y="1080" width="624" height="24"/>
-  <object id="6" type="killing_floor" x="1753" y="1879" width="96" height="24"/>
-  <object id="7" type="killing_floor" x="1920" y="1878" width="96" height="24"/>
-  <object id="8" type="killing_floor" x="2088" y="1878" width="168" height="24"/>
-  <object id="9" type="killing_floor" x="576" y="1920" width="360" height="24"/>
-  <object id="10" name="entrance1" type="door" x="1296" y="1800" width="24" height="48">
+  <object type="killing_floor" x="1176" y="1080" width="624" height="24"/>
+  <object type="killing_floor" x="1753" y="1879" width="96" height="24"/>
+  <object type="killing_floor" x="1920" y="1878" width="96" height="24"/>
+  <object type="killing_floor" x="2088" y="1878" width="168" height="24"/>
+  <object type="killing_floor" x="576" y="1920" width="360" height="24"/>
+  <object name="entrance1" type="door" x="1296" y="1800" width="24" height="48">
    <properties>
     <property name="level" value="black-caverns"/>
     <property name="to" value="entrance2"/>
    </properties>
   </object>
-  <object id="11" name="entrance2" type="door" x="1272" y="2064" width="24" height="48">
+  <object name="entrance2" type="door" x="1272" y="2064" width="24" height="48">
    <properties>
     <property name="level" value="black-caverns"/>
     <property name="to" value="entrance3"/>
    </properties>
   </object>
-  <object id="12" name="entrance3" type="door" x="1488" y="2064" width="24" height="48">
+  <object name="entrance3" type="door" x="1488" y="2064" width="24" height="48">
    <properties>
     <property name="level" value="black-caverns"/>
     <property name="to" value="entrance4"/>
    </properties>
   </object>
-  <object id="13" name="entrance4" type="door" x="1488" y="1848" width="24" height="48">
+  <object name="entrance4" type="door" x="1488" y="1848" width="24" height="48">
    <properties>
     <property name="level" value="black-caverns"/>
     <property name="to" value="entrance1"/>
    </properties>
   </object>
-  <object id="14" type="movingplatform" x="3168" y="1008" width="121" height="16">
+  <object type="movingplatform" x="3168" y="1008" width="121" height="16">
    <properties>
     <property name="chain" value="5"/>
     <property name="drop" value="false"/>
@@ -94,19 +94,19 @@
     <property name="touchstart" value="true"/>
    </properties>
   </object>
-  <object id="15" type="killing_floor" x="3168" y="1080" width="24" height="24"/>
-  <object id="16" type="killing_floor" x="3240" y="1128" width="24" height="24"/>
-  <object id="17" type="killing_floor" x="3264" y="1176" width="24" height="24"/>
-  <object id="18" type="killing_floor" x="3168" y="1224" width="24" height="24"/>
-  <object id="19" type="killing_floor" x="3192" y="1248" width="24" height="24"/>
-  <object id="20" type="killing_floor" x="3264" y="1320" width="24" height="24"/>
-  <object id="21" type="killing_floor" x="3216" y="1392" width="24" height="24"/>
-  <object id="22" type="killing_floor" x="3168" y="1464" width="24" height="24"/>
-  <object id="23" type="killing_floor" x="3192" y="1512" width="24" height="24"/>
-  <object id="24" type="killing_floor" x="3264" y="1584" width="24" height="24"/>
-  <object id="25" type="killing_floor" x="3216" y="1632" width="24" height="24"/>
-  <object id="26" type="killing_floor" x="3168" y="1704" width="24" height="24"/>
-  <object id="27" type="spawn" x="2040" y="1992" width="67" height="67">
+  <object type="killing_floor" x="3168" y="1080" width="24" height="24"/>
+  <object type="killing_floor" x="3240" y="1128" width="24" height="24"/>
+  <object type="killing_floor" x="3264" y="1176" width="24" height="24"/>
+  <object type="killing_floor" x="3168" y="1224" width="24" height="24"/>
+  <object type="killing_floor" x="3192" y="1248" width="24" height="24"/>
+  <object type="killing_floor" x="3264" y="1320" width="24" height="24"/>
+  <object type="killing_floor" x="3216" y="1392" width="24" height="24"/>
+  <object type="killing_floor" x="3168" y="1464" width="24" height="24"/>
+  <object type="killing_floor" x="3192" y="1512" width="24" height="24"/>
+  <object type="killing_floor" x="3264" y="1584" width="24" height="24"/>
+  <object type="killing_floor" x="3216" y="1632" width="24" height="24"/>
+  <object type="killing_floor" x="3168" y="1704" width="24" height="24"/>
+  <object type="spawn" x="2040" y="1992" width="67" height="67">
    <properties>
     <property name="enemytype" value="turkey"/>
     <property name="nodeType" value="enemy"/>
@@ -115,7 +115,7 @@
     <property name="velocityX" value="-50"/>
    </properties>
   </object>
-  <object id="28" type="spawn" x="2232" y="2016" width="67" height="67">
+  <object type="spawn" x="2232" y="2016" width="67" height="67">
    <properties>
     <property name="enemytype" value="turkey"/>
     <property name="nodeType" value="enemy"/>
@@ -124,7 +124,7 @@
     <property name="velocityX" value="-50"/>
    </properties>
   </object>
-  <object id="29" type="spawn" x="2880" y="1344" width="67" height="67">
+  <object type="spawn" x="2880" y="1344" width="67" height="67">
    <properties>
     <property name="enemytype" value="turkey"/>
     <property name="nodeType" value="enemy"/>
@@ -133,7 +133,7 @@
     <property name="velocityX" value="-50"/>
    </properties>
   </object>
-  <object id="30" type="spawn" x="2736" y="1248" width="67" height="67">
+  <object type="spawn" x="2736" y="1248" width="67" height="67">
    <properties>
     <property name="enemytype" value="turkey"/>
     <property name="nodeType" value="enemy"/>
@@ -142,7 +142,7 @@
     <property name="velocityX" value="-50"/>
    </properties>
   </object>
-  <object id="31" type="spawn" x="2784" y="864" width="67" height="67">
+  <object type="spawn" x="2784" y="864" width="67" height="67">
    <properties>
     <property name="enemytype" value="turkey"/>
     <property name="nodeType" value="enemy"/>
@@ -151,7 +151,7 @@
     <property name="velocityX" value="-50"/>
    </properties>
   </object>
-  <object id="32" type="spawn" x="2304" y="888" width="67" height="67">
+  <object type="spawn" x="2304" y="888" width="67" height="67">
    <properties>
     <property name="enemytype" value="turkey"/>
     <property name="nodeType" value="enemy"/>
@@ -160,7 +160,7 @@
     <property name="velocityX" value="-50"/>
    </properties>
   </object>
-  <object id="33" type="liquid" x="864" y="2064" width="192" height="24">
+  <object type="liquid" x="864" y="2064" width="192" height="24">
    <properties>
     <property name="drag" value="true"/>
     <property name="drown" value="true"/>
@@ -168,7 +168,7 @@
     <property name="sprite" value="images/liquid/grapedrink.png"/>
    </properties>
   </object>
-  <object id="34" type="liquid" x="384" y="1032" width="96" height="24">
+  <object type="liquid" x="384" y="1032" width="96" height="24">
    <properties>
     <property name="drag" value="true"/>
     <property name="drown" value="true"/>
@@ -176,7 +176,7 @@
     <property name="sprite" value="images/liquid/grapedrink.png"/>
    </properties>
   </object>
-  <object id="35" type="liquid" x="1032" y="1872" width="192" height="24">
+  <object type="liquid" x="1032" y="1872" width="192" height="24">
    <properties>
     <property name="drag" value="true"/>
     <property name="drown" value="true"/>
@@ -184,14 +184,14 @@
     <property name="sprite" value="images/liquid/grapedrink.png"/>
    </properties>
   </object>
-  <object id="36" type="movingplatform" x="741" y="1293" width="49" height="32">
+  <object type="movingplatform" x="741" y="1293" width="49" height="32">
    <properties>
     <property name="line" value="platform"/>
     <property name="speed" value="1"/>
     <property name="sprite" value="images/platforms/blackcavernsplatform.png"/>
    </properties>
   </object>
-  <object id="37" type="movingplatform" x="876" y="1203" width="49" height="32">
+  <object type="movingplatform" x="876" y="1203" width="49" height="32">
    <properties>
     <property name="direction" value="-1"/>
     <property name="line" value="platform2"/>
@@ -199,7 +199,7 @@
     <property name="sprite" value="images/platforms/blackcavernsplatform.png"/>
    </properties>
   </object>
-  <object id="38" type="movingplatform" x="1269" y="1041" width="49" height="32">
+  <object type="movingplatform" x="1269" y="1041" width="49" height="32">
    <properties>
     <property name="direction" value="-1"/>
     <property name="line" value="platform3"/>
@@ -207,14 +207,14 @@
     <property name="sprite" value="images/platforms/blackcavernsplatform.png"/>
    </properties>
   </object>
-  <object id="39" type="movingplatform" x="1655" y="1040" width="49" height="32">
+  <object type="movingplatform" x="1655" y="1040" width="49" height="32">
    <properties>
     <property name="line" value="platform4"/>
     <property name="speed" value="1.5"/>
     <property name="sprite" value="images/platforms/blackcavernsplatform.png"/>
    </properties>
   </object>
-  <object id="40" name="exit" type="door" x="2592" y="1248" width="24" height="48">
+  <object name="exit" type="door" x="2592" y="1248" width="24" height="48">
    <properties>
     <property name="info" value="Hold up! You'll need a black caverns key to unlock this door."/>
     <property name="key" value="black_caverns"/>
@@ -222,20 +222,20 @@
     <property name="to" value="main"/>
    </properties>
   </object>
-  <object id="41" name="health" type="spawn" x="816" y="2040" width="24" height="24">
+  <object name="health" type="spawn" x="816" y="2040" width="24" height="24">
    <properties>
     <property name="nodeType" value="token"/>
     <property name="spawnType" value="keypress"/>
    </properties>
   </object>
-  <object id="42" name="health" type="spawn" x="3288" y="1824" width="24" height="24">
+  <object name="health" type="spawn" x="3288" y="1824" width="24" height="24">
    <properties>
     <property name="message" value="Oh look, Health!"/>
     <property name="nodeType" value="token"/>
     <property name="spawnType" value="keypress"/>
    </properties>
   </object>
-  <object id="43" type="sprite" x="168" y="1416" width="24" height="24">
+  <object type="sprite" x="168" y="1416" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -246,7 +246,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="44" type="sprite" x="192" y="1512" width="24" height="24">
+  <object type="sprite" x="192" y="1512" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -257,7 +257,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="45" type="sprite" x="240" y="1464" width="24" height="24">
+  <object type="sprite" x="240" y="1464" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -268,7 +268,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="46" type="sprite" x="288" y="1272" width="24" height="24">
+  <object type="sprite" x="288" y="1272" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -279,7 +279,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="47" type="sprite" x="240" y="1368" width="24" height="24">
+  <object type="sprite" x="240" y="1368" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -290,7 +290,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="48" type="sprite" x="192" y="1272" width="24" height="24">
+  <object type="sprite" x="192" y="1272" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -301,7 +301,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="49" type="sprite" x="288" y="1176" width="24" height="24">
+  <object type="sprite" x="288" y="1176" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -312,7 +312,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="50" type="sprite" x="240" y="1032" width="24" height="24">
+  <object type="sprite" x="240" y="1032" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -323,7 +323,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="51" type="sprite" x="216" y="1128" width="24" height="24">
+  <object type="sprite" x="216" y="1128" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -334,7 +334,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="52" type="sprite" x="312" y="984" width="24" height="24">
+  <object type="sprite" x="312" y="984" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -345,7 +345,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="53" type="sprite" x="240" y="936" width="24" height="24">
+  <object type="sprite" x="240" y="936" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -356,7 +356,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="54" type="sprite" x="480" y="936" width="24" height="24">
+  <object type="sprite" x="480" y="936" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -367,7 +367,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="55" type="sprite" x="432" y="984" width="24" height="24">
+  <object type="sprite" x="432" y="984" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -378,7 +378,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="56" type="sprite" x="384" y="888" width="24" height="24">
+  <object type="sprite" x="384" y="888" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -389,7 +389,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="57" type="sprite" x="456" y="1200" width="24" height="24">
+  <object type="sprite" x="456" y="1200" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -400,7 +400,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="58" type="sprite" x="528" y="1344" width="24" height="24">
+  <object type="sprite" x="528" y="1344" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -411,7 +411,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="59" type="sprite" x="432" y="1392" width="24" height="24">
+  <object type="sprite" x="432" y="1392" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -422,7 +422,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="60" type="sprite" x="528" y="1152" width="24" height="24">
+  <object type="sprite" x="528" y="1152" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -433,7 +433,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="61" type="sprite" x="624" y="1368" width="24" height="24">
+  <object type="sprite" x="624" y="1368" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -444,7 +444,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="62" type="sprite" x="288" y="1680" width="24" height="24">
+  <object type="sprite" x="288" y="1680" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -455,7 +455,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="63" type="sprite" x="216" y="1608" width="24" height="24">
+  <object type="sprite" x="216" y="1608" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -466,7 +466,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="64" type="sprite" x="432" y="1680" width="24" height="24">
+  <object type="sprite" x="432" y="1680" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -477,7 +477,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="65" type="sprite" x="408" y="1776" width="24" height="24">
+  <object type="sprite" x="408" y="1776" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -488,7 +488,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="66" type="sprite" x="528" y="1752" width="24" height="24">
+  <object type="sprite" x="528" y="1752" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -499,7 +499,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="67" type="sprite" x="624" y="1704" width="24" height="24">
+  <object type="sprite" x="624" y="1704" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -510,7 +510,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="68" type="sprite" x="672" y="1824" width="24" height="24">
+  <object type="sprite" x="672" y="1824" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -521,7 +521,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="69" type="sprite" x="696" y="1776" width="24" height="24">
+  <object type="sprite" x="696" y="1776" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -532,7 +532,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="70" type="sprite" x="768" y="1656" width="24" height="24">
+  <object type="sprite" x="768" y="1656" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -543,7 +543,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="71" type="sprite" x="792" y="1872" width="24" height="24">
+  <object type="sprite" x="792" y="1872" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -554,7 +554,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="72" type="sprite" x="888" y="1752" width="24" height="24">
+  <object type="sprite" x="888" y="1752" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -565,7 +565,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="73" type="sprite" x="960" y="1680" width="24" height="24">
+  <object type="sprite" x="960" y="1680" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -576,7 +576,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="74" type="sprite" x="984" y="1824" width="24" height="24">
+  <object type="sprite" x="984" y="1824" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -587,7 +587,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="75" type="sprite" x="1080" y="1728" width="24" height="24">
+  <object type="sprite" x="1080" y="1728" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -598,7 +598,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="76" type="sprite" x="1200" y="1680" width="24" height="24">
+  <object type="sprite" x="1200" y="1680" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -609,7 +609,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="77" type="sprite" x="1176" y="1776" width="24" height="24">
+  <object type="sprite" x="1176" y="1776" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -620,7 +620,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="78" type="sprite" x="1296" y="1728" width="24" height="24">
+  <object type="sprite" x="1296" y="1728" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -631,7 +631,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="79" type="sprite" x="1296" y="1992" width="24" height="24">
+  <object type="sprite" x="1296" y="1992" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -642,7 +642,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="80" type="sprite" x="1128" y="1992" width="24" height="24">
+  <object type="sprite" x="1128" y="1992" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -653,7 +653,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="81" type="sprite" x="1008" y="1968" width="24" height="24">
+  <object type="sprite" x="1008" y="1968" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -664,7 +664,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="82" type="sprite" x="1224" y="2040" width="24" height="24">
+  <object type="sprite" x="1224" y="2040" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -675,7 +675,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="83" type="sprite" x="1536" y="1992" width="24" height="24">
+  <object type="sprite" x="1536" y="1992" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -686,7 +686,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="84" type="sprite" x="1776" y="1992" width="24" height="24">
+  <object type="sprite" x="1776" y="1992" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -697,7 +697,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="85" type="sprite" x="1896" y="2064" width="24" height="24">
+  <object type="sprite" x="1896" y="2064" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -708,7 +708,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="86" type="sprite" x="1968" y="2016" width="24" height="24">
+  <object type="sprite" x="1968" y="2016" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -719,7 +719,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="87" type="sprite" x="2064" y="2088" width="24" height="24">
+  <object type="sprite" x="2064" y="2088" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -730,7 +730,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="88" type="sprite" x="2136" y="2016" width="24" height="24">
+  <object type="sprite" x="2136" y="2016" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -741,7 +741,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="89" type="sprite" x="2328" y="1968" width="24" height="24">
+  <object type="sprite" x="2328" y="1968" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -752,7 +752,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="90" type="sprite" x="2472" y="2016" width="24" height="24">
+  <object type="sprite" x="2472" y="2016" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -763,7 +763,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="91" type="sprite" x="2424" y="1944" width="24" height="24">
+  <object type="sprite" x="2424" y="1944" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -774,7 +774,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="92" type="sprite" x="2448" y="2088" width="24" height="24">
+  <object type="sprite" x="2448" y="2088" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -785,7 +785,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="93" type="sprite" x="2376" y="2040" width="24" height="24">
+  <object type="sprite" x="2376" y="2040" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -796,7 +796,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="94" type="sprite" x="2184" y="2064" width="24" height="24">
+  <object type="sprite" x="2184" y="2064" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -807,7 +807,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="95" type="sprite" x="2112" y="1752" width="24" height="24">
+  <object type="sprite" x="2112" y="1752" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -818,7 +818,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="96" type="sprite" x="2040" y="1800" width="24" height="24">
+  <object type="sprite" x="2040" y="1800" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -829,7 +829,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="97" type="sprite" x="1992" y="1752" width="24" height="24">
+  <object type="sprite" x="1992" y="1752" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -840,7 +840,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="98" type="sprite" x="1944" y="1824" width="24" height="24">
+  <object type="sprite" x="1944" y="1824" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -851,7 +851,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="99" type="sprite" x="1896" y="1752" width="24" height="24">
+  <object type="sprite" x="1896" y="1752" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -862,7 +862,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="100" type="sprite" x="1752" y="1800" width="24" height="24">
+  <object type="sprite" x="1752" y="1800" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -873,7 +873,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="101" type="sprite" x="1656" y="1776" width="24" height="24">
+  <object type="sprite" x="1656" y="1776" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -884,7 +884,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="102" type="sprite" x="1536" y="1752" width="24" height="24">
+  <object type="sprite" x="1536" y="1752" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -895,7 +895,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="103" type="sprite" x="1560" y="1848" width="24" height="24">
+  <object type="sprite" x="1560" y="1848" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -906,7 +906,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="104" type="sprite" x="1464" y="1776" width="24" height="24">
+  <object type="sprite" x="1464" y="1776" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -917,7 +917,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="105" type="sprite" x="2256" y="1512" width="24" height="24">
+  <object type="sprite" x="2256" y="1512" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -928,7 +928,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="106" type="sprite" x="2280" y="1704" width="24" height="24">
+  <object type="sprite" x="2280" y="1704" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -939,7 +939,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="107" type="sprite" x="2352" y="1464" width="24" height="24">
+  <object type="sprite" x="2352" y="1464" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -950,7 +950,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="108" type="sprite" x="2472" y="1488" width="24" height="24">
+  <object type="sprite" x="2472" y="1488" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -961,7 +961,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="109" type="sprite" x="2520" y="1248" width="24" height="24">
+  <object type="sprite" x="2520" y="1248" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -972,7 +972,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="110" type="sprite" x="2568" y="1176" width="24" height="24">
+  <object type="sprite" x="2568" y="1176" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -983,7 +983,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="111" type="sprite" x="2664" y="1248" width="24" height="24">
+  <object type="sprite" x="2664" y="1248" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -994,7 +994,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="112" type="sprite" x="2712" y="1152" width="24" height="24">
+  <object type="sprite" x="2712" y="1152" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1005,7 +1005,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="113" type="sprite" x="2760" y="1368" width="24" height="24">
+  <object type="sprite" x="2760" y="1368" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1016,7 +1016,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="114" type="sprite" x="2856" y="1248" width="24" height="24">
+  <object type="sprite" x="2856" y="1248" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1027,7 +1027,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="115" type="sprite" x="2808" y="1176" width="24" height="24">
+  <object type="sprite" x="2808" y="1176" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1038,7 +1038,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="116" type="sprite" x="2928" y="1320" width="24" height="24">
+  <object type="sprite" x="2928" y="1320" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1049,7 +1049,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="117" type="sprite" x="2688" y="1368" width="24" height="24">
+  <object type="sprite" x="2688" y="1368" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1060,7 +1060,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="118" type="sprite" x="2904" y="1176" width="24" height="24">
+  <object type="sprite" x="2904" y="1176" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1071,7 +1071,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="119" type="sprite" x="2688" y="912" width="24" height="24">
+  <object type="sprite" x="2688" y="912" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1082,7 +1082,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="120" type="sprite" x="2592" y="864" width="24" height="24">
+  <object type="sprite" x="2592" y="864" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1093,7 +1093,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="121" type="sprite" x="2424" y="936" width="24" height="24">
+  <object type="sprite" x="2424" y="936" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1104,7 +1104,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="122" type="sprite" x="2424" y="840" width="24" height="24">
+  <object type="sprite" x="2424" y="840" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1115,7 +1115,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="123" type="sprite" x="2232" y="864" width="24" height="24">
+  <object type="sprite" x="2232" y="864" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1126,7 +1126,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="124" type="sprite" x="1776" y="912" width="24" height="24">
+  <object type="sprite" x="1776" y="912" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1137,7 +1137,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="125" type="sprite" x="1728" y="984" width="24" height="24">
+  <object type="sprite" x="1728" y="984" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1148,7 +1148,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="126" type="sprite" x="1440" y="936" width="24" height="24">
+  <object type="sprite" x="1440" y="936" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1159,7 +1159,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="127" type="sprite" x="1680" y="912" width="24" height="24">
+  <object type="sprite" x="1680" y="912" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1170,7 +1170,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="128" type="sprite" x="1536" y="960" width="24" height="24">
+  <object type="sprite" x="1536" y="960" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1181,7 +1181,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="129" type="sprite" x="1896" y="912" width="24" height="24">
+  <object type="sprite" x="1896" y="912" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1192,7 +1192,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="130" type="sprite" x="1824" y="960" width="24" height="24">
+  <object type="sprite" x="1824" y="960" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1203,7 +1203,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="131" type="sprite" x="2040" y="864" width="24" height="24">
+  <object type="sprite" x="2040" y="864" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1214,7 +1214,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="132" type="sprite" x="2208" y="960" width="24" height="24">
+  <object type="sprite" x="2208" y="960" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1225,7 +1225,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="133" type="sprite" x="1848" y="840" width="24" height="24">
+  <object type="sprite" x="1848" y="840" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1236,7 +1236,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="134" type="sprite" x="1320" y="1008" width="24" height="24">
+  <object type="sprite" x="1320" y="1008" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1247,7 +1247,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="135" type="sprite" x="1416" y="984" width="24" height="24">
+  <object type="sprite" x="1416" y="984" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1258,7 +1258,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="136" type="sprite" x="1368" y="936" width="24" height="24">
+  <object type="sprite" x="1368" y="936" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1269,7 +1269,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="137" type="sprite" x="1272" y="936" width="24" height="24">
+  <object type="sprite" x="1272" y="936" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1280,7 +1280,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="138" type="sprite" x="1128" y="960" width="24" height="24">
+  <object type="sprite" x="1128" y="960" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1291,7 +1291,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="139" type="sprite" x="1032" y="888" width="24" height="24">
+  <object type="sprite" x="1032" y="888" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1302,7 +1302,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="140" type="sprite" x="936" y="984" width="24" height="24">
+  <object type="sprite" x="936" y="984" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1313,7 +1313,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="141" type="sprite" x="816" y="936" width="24" height="24">
+  <object type="sprite" x="816" y="936" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1324,7 +1324,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="142" type="sprite" x="696" y="1128" width="24" height="24">
+  <object type="sprite" x="696" y="1128" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1335,7 +1335,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="143" type="sprite" x="720" y="1224" width="24" height="24">
+  <object type="sprite" x="720" y="1224" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1346,7 +1346,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="144" type="sprite" x="888" y="1176" width="24" height="24">
+  <object type="sprite" x="888" y="1176" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1357,7 +1357,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="145" type="sprite" x="744" y="1032" width="24" height="24">
+  <object type="sprite" x="744" y="1032" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1368,7 +1368,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="146" type="sprite" x="888" y="1344" width="24" height="24">
+  <object type="sprite" x="888" y="1344" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1379,7 +1379,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="147" type="sprite" x="816" y="1392" width="24" height="24">
+  <object type="sprite" x="816" y="1392" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1390,7 +1390,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="148" type="sprite" x="792" y="1248" width="24" height="24">
+  <object type="sprite" x="792" y="1248" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1401,7 +1401,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="149" type="sprite" x="720" y="912" width="24" height="24">
+  <object type="sprite" x="720" y="912" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1412,7 +1412,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="150" type="sprite" x="720" y="1416" width="24" height="24">
+  <object type="sprite" x="720" y="1416" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1423,7 +1423,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="151" type="sprite" x="2784" y="936" width="24" height="24">
+  <object type="sprite" x="2784" y="936" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1434,7 +1434,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="152" type="sprite" x="2880" y="864" width="24" height="24">
+  <object type="sprite" x="2880" y="864" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1445,7 +1445,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="153" type="sprite" x="2880" y="984" width="24" height="24">
+  <object type="sprite" x="2880" y="984" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1456,7 +1456,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="154" type="sprite" x="3000" y="960" width="24" height="24">
+  <object type="sprite" x="3000" y="960" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1467,7 +1467,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="155" type="sprite" x="3048" y="888" width="24" height="24">
+  <object type="sprite" x="3048" y="888" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1478,7 +1478,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="156" type="sprite" x="3096" y="960" width="24" height="24">
+  <object type="sprite" x="3096" y="960" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1489,7 +1489,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="157" type="sprite" x="3144" y="912" width="24" height="24">
+  <object type="sprite" x="3144" y="912" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1500,7 +1500,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="158" type="sprite" x="3216" y="864" width="24" height="24">
+  <object type="sprite" x="3216" y="864" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1511,7 +1511,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="159" type="sprite" x="3192" y="960" width="24" height="24">
+  <object type="sprite" x="3192" y="960" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1522,7 +1522,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="160" type="sprite" x="3240" y="1056" width="24" height="24">
+  <object type="sprite" x="3240" y="1056" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1533,7 +1533,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="161" type="sprite" x="3192" y="1152" width="24" height="24">
+  <object type="sprite" x="3192" y="1152" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1544,7 +1544,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="162" type="sprite" x="3240" y="1248" width="24" height="24">
+  <object type="sprite" x="3240" y="1248" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1555,7 +1555,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="163" type="sprite" x="3192" y="1320" width="24" height="24">
+  <object type="sprite" x="3192" y="1320" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1566,7 +1566,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="164" type="sprite" x="3240" y="1464" width="24" height="24">
+  <object type="sprite" x="3240" y="1464" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1577,7 +1577,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="165" type="sprite" x="3240" y="1536" width="24" height="24">
+  <object type="sprite" x="3240" y="1536" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1588,7 +1588,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="166" type="sprite" x="3168" y="1536" width="24" height="24">
+  <object type="sprite" x="3168" y="1536" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1599,7 +1599,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="167" type="sprite" x="3216" y="1608" width="24" height="24">
+  <object type="sprite" x="3216" y="1608" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1610,7 +1610,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="168" type="sprite" x="3240" y="1704" width="24" height="24">
+  <object type="sprite" x="3240" y="1704" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1621,7 +1621,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="169" type="sprite" x="3192" y="1752" width="24" height="24">
+  <object type="sprite" x="3192" y="1752" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1632,7 +1632,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="170" type="sprite" x="3264" y="1776" width="24" height="24">
+  <object type="sprite" x="3264" y="1776" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1643,7 +1643,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="171" type="sprite" x="3336" y="1752" width="24" height="24">
+  <object type="sprite" x="3336" y="1752" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1654,7 +1654,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="172" type="sprite" x="3360" y="1824" width="24" height="24">
+  <object type="sprite" x="3360" y="1824" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1665,7 +1665,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="173" type="sprite" x="3432" y="1728" width="24" height="24">
+  <object type="sprite" x="3432" y="1728" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1676,7 +1676,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="174" type="sprite" x="3432" y="1872" width="24" height="24">
+  <object type="sprite" x="3432" y="1872" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1687,7 +1687,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="175" type="sprite" x="3480" y="1800" width="24" height="24">
+  <object type="sprite" x="3480" y="1800" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1698,7 +1698,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="176" type="sprite" x="3552" y="1728" width="24" height="24">
+  <object type="sprite" x="3552" y="1728" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1709,7 +1709,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="177" type="sprite" x="3552" y="1872" width="24" height="24">
+  <object type="sprite" x="3552" y="1872" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1720,7 +1720,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="178" type="sprite" x="3576" y="1944" width="24" height="24">
+  <object type="sprite" x="3576" y="1944" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1731,32 +1731,32 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="179" type="movingplatform" x="3720" y="408" width="49" height="32">
+  <object type="movingplatform" x="3720" y="408" width="49" height="32">
    <properties>
     <property name="line" value="platformup"/>
     <property name="speed" value="1.1"/>
     <property name="sprite" value="images/platforms/blackcavernsplatform.png"/>
    </properties>
   </object>
-  <object id="180" type="bouncer" x="1656" y="480" width="192" height="48">
+  <object type="bouncer" x="1656" y="480" width="192" height="48">
    <properties>
     <property name="dbval" value="1100"/>
    </properties>
   </object>
-  <object id="181" type="bouncer" x="1224" y="480" width="192" height="48">
+  <object type="bouncer" x="1224" y="480" width="192" height="48">
    <properties>
     <property name="dbval" value="1100"/>
    </properties>
   </object>
-  <object id="182" type="bouncer" x="864" y="480" width="144" height="48">
+  <object type="bouncer" x="864" y="480" width="144" height="48">
    <properties>
     <property name="dbval" value="1100"/>
    </properties>
   </object>
-  <object id="183" type="killing_floor" x="1008" y="600" width="216" height="24"/>
-  <object id="184" type="killing_floor" x="1416" y="576" width="240" height="24"/>
-  <object id="185" type="killing_floor" x="3720" y="24" width="48" height="24"/>
-  <object id="186" type="spawn" x="2688" y="72" width="67" height="67">
+  <object type="killing_floor" x="1008" y="600" width="216" height="24"/>
+  <object type="killing_floor" x="1416" y="576" width="240" height="24"/>
+  <object type="killing_floor" x="3720" y="24" width="48" height="24"/>
+  <object type="spawn" x="2688" y="72" width="67" height="67">
    <properties>
     <property name="enemytype" value="turkey"/>
     <property name="nodeType" value="enemy"/>
@@ -1765,7 +1765,7 @@
     <property name="velocityX" value="-50"/>
    </properties>
   </object>
-  <object id="187" type="sprite" x="3264" y="720" width="24" height="24">
+  <object type="sprite" x="3264" y="720" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1776,7 +1776,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="188" type="sprite" x="3216" y="672" width="24" height="24">
+  <object type="sprite" x="3216" y="672" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1787,7 +1787,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="189" type="sprite" x="3312" y="552" width="24" height="24">
+  <object type="sprite" x="3312" y="552" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1798,7 +1798,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="190" type="sprite" x="3360" y="408" width="24" height="24">
+  <object type="sprite" x="3360" y="408" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1809,7 +1809,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="191" type="sprite" x="3288" y="432" width="24" height="24">
+  <object type="sprite" x="3288" y="432" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1820,7 +1820,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="192" type="sprite" x="3432" y="456" width="24" height="24">
+  <object type="sprite" x="3432" y="456" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1831,7 +1831,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="193" type="sprite" x="3552" y="384" width="24" height="24">
+  <object type="sprite" x="3552" y="384" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1842,7 +1842,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="194" type="sprite" x="3456" y="336" width="24" height="24">
+  <object type="sprite" x="3456" y="336" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1853,7 +1853,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="195" type="sprite" x="3744" y="216" width="24" height="24">
+  <object type="sprite" x="3744" y="216" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1864,7 +1864,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="196" type="sprite" x="3696" y="360" width="24" height="24">
+  <object type="sprite" x="3696" y="360" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1875,7 +1875,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="197" type="sprite" x="3528" y="144" width="24" height="24">
+  <object type="sprite" x="3528" y="144" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1886,7 +1886,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="198" type="sprite" x="3432" y="192" width="24" height="24">
+  <object type="sprite" x="3432" y="192" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1897,7 +1897,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="199" type="sprite" x="3288" y="144" width="24" height="24">
+  <object type="sprite" x="3288" y="144" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1908,7 +1908,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="200" type="sprite" x="3144" y="144" width="24" height="24">
+  <object type="sprite" x="3144" y="144" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1919,7 +1919,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="201" type="sprite" x="3000" y="96" width="24" height="24">
+  <object type="sprite" x="3000" y="96" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1930,7 +1930,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="202" type="sprite" x="2880" y="168" width="24" height="24">
+  <object type="sprite" x="2880" y="168" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1941,7 +1941,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="203" type="sprite" x="2856" y="72" width="24" height="24">
+  <object type="sprite" x="2856" y="72" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1952,7 +1952,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="204" type="sprite" x="2664" y="192" width="24" height="24">
+  <object type="sprite" x="2664" y="192" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1963,7 +1963,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="205" type="sprite" x="2784" y="120" width="24" height="24">
+  <object type="sprite" x="2784" y="120" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1974,7 +1974,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="206" type="sprite" x="2760" y="192" width="24" height="24">
+  <object type="sprite" x="2760" y="192" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1985,7 +1985,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="207" type="sprite" x="2616" y="72" width="24" height="24">
+  <object type="sprite" x="2616" y="72" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -1996,7 +1996,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="208" type="sprite" x="2568" y="168" width="24" height="24">
+  <object type="sprite" x="2568" y="168" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2007,7 +2007,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="209" type="sprite" x="2544" y="96" width="24" height="24">
+  <object type="sprite" x="2544" y="96" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2018,7 +2018,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="210" type="sprite" x="2448" y="120" width="24" height="24">
+  <object type="sprite" x="2448" y="120" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2029,7 +2029,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="211" type="sprite" x="2352" y="48" width="24" height="24">
+  <object type="sprite" x="2352" y="48" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2040,7 +2040,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="212" type="sprite" x="2160" y="48" width="24" height="24">
+  <object type="sprite" x="2160" y="48" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2051,7 +2051,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="213" type="sprite" x="2040" y="48" width="24" height="24">
+  <object type="sprite" x="2040" y="48" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2062,7 +2062,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="214" type="sprite" x="2136" y="120" width="24" height="24">
+  <object type="sprite" x="2136" y="120" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2073,7 +2073,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="215" type="sprite" x="2304" y="144" width="24" height="24">
+  <object type="sprite" x="2304" y="144" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2084,7 +2084,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="216" type="sprite" x="2232" y="96" width="24" height="24">
+  <object type="sprite" x="2232" y="96" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2095,7 +2095,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="217" type="sprite" x="2040" y="168" width="24" height="24">
+  <object type="sprite" x="2040" y="168" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2106,7 +2106,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="218" type="sprite" x="1848" y="144" width="24" height="24">
+  <object type="sprite" x="1848" y="144" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2117,7 +2117,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="219" type="sprite" x="1824" y="216" width="24" height="24">
+  <object type="sprite" x="1824" y="216" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2128,7 +2128,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="220" type="sprite" x="1992" y="240" width="24" height="24">
+  <object type="sprite" x="1992" y="240" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2139,7 +2139,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="221" type="sprite" x="1920" y="192" width="24" height="24">
+  <object type="sprite" x="1920" y="192" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2150,7 +2150,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="222" type="sprite" x="1872" y="336" width="24" height="24">
+  <object type="sprite" x="1872" y="336" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2161,7 +2161,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="223" type="sprite" x="1704" y="384" width="24" height="24">
+  <object type="sprite" x="1704" y="384" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2172,7 +2172,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="224" type="sprite" x="1704" y="240" width="24" height="24">
+  <object type="sprite" x="1704" y="240" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2183,7 +2183,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="225" type="sprite" x="1536" y="312" width="24" height="24">
+  <object type="sprite" x="1536" y="312" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2194,7 +2194,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="226" type="sprite" x="1536" y="168" width="24" height="24">
+  <object type="sprite" x="1536" y="168" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2205,7 +2205,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="227" type="sprite" x="1536" y="432" width="24" height="24">
+  <object type="sprite" x="1536" y="432" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2216,7 +2216,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="228" type="sprite" x="1392" y="312" width="24" height="24">
+  <object type="sprite" x="1392" y="312" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2227,7 +2227,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="229" type="sprite" x="1368" y="216" width="24" height="24">
+  <object type="sprite" x="1368" y="216" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2238,7 +2238,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="230" type="sprite" x="1392" y="144" width="24" height="24">
+  <object type="sprite" x="1392" y="144" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2249,7 +2249,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="231" type="sprite" x="1248" y="240" width="24" height="24">
+  <object type="sprite" x="1248" y="240" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2260,7 +2260,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="232" type="sprite" x="984" y="192" width="24" height="24">
+  <object type="sprite" x="984" y="192" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2271,7 +2271,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="233" type="sprite" x="984" y="456" width="24" height="24">
+  <object type="sprite" x="984" y="456" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2282,7 +2282,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="234" type="sprite" x="1152" y="408" width="24" height="24">
+  <object type="sprite" x="1152" y="408" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2293,7 +2293,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="235" type="sprite" x="1152" y="264" width="24" height="24">
+  <object type="sprite" x="1152" y="264" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2304,7 +2304,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="236" type="sprite" x="984" y="336" width="24" height="24">
+  <object type="sprite" x="984" y="336" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2315,7 +2315,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="237" type="sprite" x="1296" y="360" width="24" height="24">
+  <object type="sprite" x="1296" y="360" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2326,7 +2326,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="238" type="sprite" x="1440" y="480" width="24" height="24">
+  <object type="sprite" x="1440" y="480" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2337,7 +2337,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="239" type="sprite" x="1104" y="528" width="24" height="24">
+  <object type="sprite" x="1104" y="528" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2348,7 +2348,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="240" type="sprite" x="912" y="360" width="24" height="24">
+  <object type="sprite" x="912" y="360" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2359,7 +2359,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="241" type="sprite" x="1104" y="144" width="24" height="24">
+  <object type="sprite" x="1104" y="144" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2370,7 +2370,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="242" type="sprite" x="1224" y="144" width="24" height="24">
+  <object type="sprite" x="1224" y="144" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2381,7 +2381,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="243" type="sprite" x="1824" y="432" width="24" height="24">
+  <object type="sprite" x="1824" y="432" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2392,7 +2392,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="244" type="sprite" x="1680" y="120" width="24" height="24">
+  <object type="sprite" x="1680" y="120" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2403,7 +2403,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="245" type="sprite" x="1536" y="552" width="24" height="24">
+  <object type="sprite" x="1536" y="552" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2414,7 +2414,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="246" type="sprite" x="504" y="384" width="24" height="24">
+  <object type="sprite" x="504" y="384" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2425,7 +2425,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="247" type="sprite" x="504" y="504" width="24" height="24">
+  <object type="sprite" x="504" y="504" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2436,7 +2436,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="248" type="sprite" x="432" y="408" width="24" height="24">
+  <object type="sprite" x="432" y="408" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2447,7 +2447,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="249" type="sprite" x="576" y="312" width="24" height="24">
+  <object type="sprite" x="576" y="312" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2458,7 +2458,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="250" type="sprite" x="624" y="432" width="24" height="24">
+  <object type="sprite" x="624" y="432" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2469,7 +2469,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="251" type="sprite" x="696" y="312" width="24" height="24">
+  <object type="sprite" x="696" y="312" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2480,7 +2480,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="252" type="sprite" x="816" y="288" width="24" height="24">
+  <object type="sprite" x="816" y="288" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2491,7 +2491,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="253" type="sprite" x="432" y="600" width="24" height="24">
+  <object type="sprite" x="432" y="600" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2502,7 +2502,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="254" type="sprite" x="480" y="792" width="24" height="24">
+  <object type="sprite" x="480" y="792" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2513,7 +2513,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="255" type="sprite" x="384" y="480" width="24" height="24">
+  <object type="sprite" x="384" y="480" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2524,7 +2524,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="256" type="sprite" x="2208" y="408" width="24" height="24">
+  <object type="sprite" x="2208" y="408" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2535,7 +2535,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="257" type="sprite" x="2400" y="408" width="24" height="24">
+  <object type="sprite" x="2400" y="408" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2546,7 +2546,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="258" type="sprite" x="2184" y="480" width="24" height="24">
+  <object type="sprite" x="2184" y="480" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2557,7 +2557,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="259" type="sprite" x="2352" y="504" width="24" height="24">
+  <object type="sprite" x="2352" y="504" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2568,7 +2568,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="260" type="sprite" x="2280" y="456" width="24" height="24">
+  <object type="sprite" x="2280" y="456" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2579,7 +2579,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="261" type="sprite" x="2544" y="408" width="24" height="24">
+  <object type="sprite" x="2544" y="408" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2590,7 +2590,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="262" type="sprite" x="2448" y="552" width="24" height="24">
+  <object type="sprite" x="2448" y="552" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2601,7 +2601,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="263" type="sprite" x="2976" y="360" width="24" height="24">
+  <object type="sprite" x="2976" y="360" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2612,7 +2612,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="264" type="sprite" x="3024" y="480" width="24" height="24">
+  <object type="sprite" x="3024" y="480" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2623,7 +2623,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="265" type="sprite" x="2928" y="456" width="24" height="24">
+  <object type="sprite" x="2928" y="456" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2634,7 +2634,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="266" type="sprite" x="2904" y="384" width="24" height="24">
+  <object type="sprite" x="2904" y="384" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2645,7 +2645,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="267" type="sprite" x="2928" y="528" width="24" height="24">
+  <object type="sprite" x="2928" y="528" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2656,7 +2656,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="268" type="sprite" x="2664" y="552" width="24" height="24">
+  <object type="sprite" x="2664" y="552" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2667,7 +2667,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="269" type="sprite" x="2640" y="456" width="24" height="24">
+  <object type="sprite" x="2640" y="456" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2678,7 +2678,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="270" type="sprite" x="2784" y="480" width="24" height="24">
+  <object type="sprite" x="2784" y="480" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2689,7 +2689,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="271" type="sprite" x="2760" y="384" width="24" height="24">
+  <object type="sprite" x="2760" y="384" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2700,7 +2700,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="272" type="sprite" x="2592" y="648" width="24" height="24">
+  <object type="sprite" x="2592" y="648" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2711,7 +2711,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="273" type="sprite" x="2448" y="648" width="24" height="24">
+  <object type="sprite" x="2448" y="648" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2722,7 +2722,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="274" type="sprite" x="2400" y="744" width="24" height="24">
+  <object type="sprite" x="2400" y="744" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2733,7 +2733,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="275" type="sprite" x="2496" y="792" width="24" height="24">
+  <object type="sprite" x="2496" y="792" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2744,7 +2744,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="276" type="sprite" x="2328" y="600" width="24" height="24">
+  <object type="sprite" x="2328" y="600" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2755,7 +2755,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="277" type="sprite" x="2232" y="576" width="24" height="24">
+  <object type="sprite" x="2232" y="576" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2766,7 +2766,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="278" type="sprite" x="2760" y="648" width="24" height="24">
+  <object type="sprite" x="2760" y="648" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2777,7 +2777,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="279" type="sprite" x="2784" y="768" width="24" height="24">
+  <object type="sprite" x="2784" y="768" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2788,7 +2788,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="280" type="sprite" x="3024" y="696" width="24" height="24">
+  <object type="sprite" x="3024" y="696" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2799,7 +2799,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="281" type="sprite" x="2568" y="552" width="24" height="24">
+  <object type="sprite" x="2568" y="552" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2810,7 +2810,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="282" type="sprite" x="3672" y="1920" width="24" height="24">
+  <object type="sprite" x="3672" y="1920" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2821,7 +2821,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="283" type="sprite" x="3672" y="2064" width="24" height="24">
+  <object type="sprite" x="3672" y="2064" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2832,7 +2832,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="284" type="sprite" x="3528" y="1992" width="24" height="24">
+  <object type="sprite" x="3528" y="1992" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2843,7 +2843,7 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="285" type="sprite" x="3624" y="1824" width="24" height="24">
+  <object type="sprite" x="3624" y="1824" width="24" height="24">
    <properties>
     <property name="animation" value="1-4,1|1-4,2|1,1"/>
     <property name="height" value="24"/>
@@ -2854,9 +2854,9 @@
     <property name="window" value="5"/>
    </properties>
   </object>
-  <object id="286" name="black_caverns" type="key" x="3624" y="2088" width="24" height="24"/>
-  <object id="287" type="climbable" x="2865" y="551" width="6" height="164"/>
-  <object id="288" type="liquid" x="3192" y="216" width="384" height="24">
+  <object name="black_caverns" type="key" x="3624" y="2088" width="24" height="24"/>
+  <object type="climbable" x="2865" y="551" width="6" height="164"/>
+  <object type="liquid" x="3192" y="216" width="384" height="24">
    <properties>
     <property name="drag" value="true"/>
     <property name="drown" value="true"/>
@@ -2864,52 +2864,52 @@
     <property name="sprite" value="images/liquid/grapedrink.png"/>
    </properties>
   </object>
-  <object id="289" type="climbable" x="753" y="1608" width="7" height="265">
+  <object type="climbable" x="753" y="1608" width="7" height="265">
    <properties>
     <property name="blockTop" value="true"/>
    </properties>
   </object>
-  <object id="290" type="climbable" x="848" y="1609" width="7" height="265">
+  <object type="climbable" x="848" y="1609" width="7" height="265">
    <properties>
     <property name="blockTop" value="true"/>
    </properties>
   </object>
-  <object id="291" name="ember" type="material" x="288" y="1776" width="24" height="24"/>
-  <object id="292" name="ember" type="material" x="1224" y="1824" width="24" height="24"/>
-  <object id="293" name="ember" type="material" x="576" y="1416" width="24" height="24"/>
-  <object id="294" name="ember" type="material" x="1008" y="1008" width="24" height="24"/>
-  <object id="295" name="ember" type="material" x="2256" y="984" width="24" height="24"/>
-  <object id="296" name="ember" type="material" x="2688" y="696" width="24" height="24"/>
-  <object id="297" name="ember" type="material" x="1896" y="456" width="24" height="24"/>
-  <object id="298" name="ember" type="material" x="2352" y="2088" width="24" height="24"/>
-  <object id="299" name="ember" type="material" x="2472" y="2088" width="24" height="24"/>
-  <object id="300" name="ember" type="material" x="2424" y="2088" width="24" height="24"/>
-  <object id="301" name="ember" type="material" x="2736" y="1440" width="24" height="24"/>
-  <object id="302" name="watermelon" type="consumable" x="324" y="1860" width="24" height="24"/>
-  <object id="303" name="pink_potion" type="detail" x="2520" y="2088" width="24" height="24">
+  <object name="ember" type="material" x="288" y="1776" width="24" height="24"/>
+  <object name="ember" type="material" x="1224" y="1824" width="24" height="24"/>
+  <object name="ember" type="material" x="576" y="1416" width="24" height="24"/>
+  <object name="ember" type="material" x="1008" y="1008" width="24" height="24"/>
+  <object name="ember" type="material" x="2256" y="984" width="24" height="24"/>
+  <object name="ember" type="material" x="2688" y="696" width="24" height="24"/>
+  <object name="ember" type="material" x="1896" y="456" width="24" height="24"/>
+  <object name="ember" type="material" x="2352" y="2088" width="24" height="24"/>
+  <object name="ember" type="material" x="2472" y="2088" width="24" height="24"/>
+  <object name="ember" type="material" x="2424" y="2088" width="24" height="24"/>
+  <object name="ember" type="material" x="2736" y="1440" width="24" height="24"/>
+  <object name="watermelon" type="consumable" x="324" y="1860" width="24" height="24"/>
+  <object name="pink_potion" type="detail" x="2520" y="2088" width="24" height="24">
    <properties>
     <property name="category" value="recipe"/>
    </properties>
   </object>
  </objectgroup>
- <objectgroup color="#ddad4c" name="movement" visible="0">
-  <object id="304" name="drumsticks" x="3216" y="1032">
+ <objectgroup color="#ddad4c" name="movement" width="0" height="0" visible="0">
+  <object name="drumsticks" x="3216" y="1032">
    <polyline points="0,0 0,792"/>
   </object>
-  <object id="305" name="platform" x="929" y="1303">
+  <object name="platform" x="929" y="1303">
    <polyline points="0,0 -177,0"/>
   </object>
-  <object id="306" name="platform2" x="929" y="1216">
+  <object name="platform2" x="929" y="1216">
    <polyline points="0,0 -177,0"/>
   </object>
-  <object id="307" name="platform3" x="1420" y="1053">
+  <object name="platform3" x="1420" y="1053">
    <polyline points="26,0 -177,0"/>
   </object>
-  <object id="308" name="platform4" x="1708" y="1053">
+  <object name="platform4" x="1708" y="1053">
    <polyline points="21,1 -187,1"/>
   </object>
-  <object id="309" name="platformup" x="3744" y="48">
-   <polyline points="0,0 0,384"/>
+  <object name="platformup" x="3744" y="48">
+   <polyline points="0,48 0,384"/>
   </object>
  </objectgroup>
 </map>


### PR DESCRIPTION
There was an issue posted on the [subreddit](https://www.reddit.com/r/hawkthorne/comments/3bmj09/black_caverns_disappearing_bug/) where the player disappears when they hit the spikes in the top left of black-caverns, this prevents the platform from going as high so that it doesn't push the player into the blocks.