### PR TITLE
Play the show door animation when entering level

### DIFF
--- a/src/maps/hallway.tmx
+++ b/src/maps/hallway.tmx
@@ -47,7 +47,6 @@
     <property name="hideable" value="true"/>
     <property name="key" value="greendale"/>
     <property name="level" value="greendale-exterior"/>
-    <property name="movetime" value="0.01"/>
     <property name="offset_hidden_y" value="-24"/>
     <property name="offset_shown_x" value="24"/>
     <property name="offset_shown_y" value="-24"/>

--- a/src/maps/house.tmx
+++ b/src/maps/house.tmx
@@ -63,6 +63,7 @@
     <property name="depth" value="2"/>
     <property name="hideable" value="true"/>
     <property name="level" value="lab"/>
+    <property name="movetime" value="1.5"/>
     <property name="offset_hidden_x" value="-12"/>
     <property name="offset_shown_x" value="-48"/>
     <property name="sound" value="false"/>

--- a/src/nodes/door.lua
+++ b/src/nodes/door.lua
@@ -45,7 +45,7 @@ function Door.new(node, collider, level)
   door.trigger = node.properties.trigger or '' -- Used to show hideable doors based on gamesave triggers.
 
   door.inventory = node.properties.inventory    
-  door.hideable = node.properties.hideable == 'true' and not app.gamesaves:active():get(door.trigger, false)
+  door.hideable = node.properties.hideable == 'true'
   door.open = app.gamesaves:active():get(door.trigger, false)
 
   -- generic support for hidden doors
@@ -93,6 +93,12 @@ function Door.new(node, collider, level)
                               node.y + y * tw, tw, tw, 0)
         end
       end
+    end
+    -- Keep door opening when re-entering a level
+    if app.gamesaves:active():get(door.trigger, false) then
+      door.position = door.position_shown
+      door.hidden = false
+      door.open = true
     end
   end
 
@@ -208,16 +214,6 @@ function Door:show(previous)
     end
   end
     end
-  end
-end
-
-function Door:hide(previous)
-  -- level check is to allow door to close on re-entry or close command
-  if self.hideable and ( (previous and previous.name == self.level) or not self.hidden ) then
-    self.hidden = true
-    self.position = utils.deepcopy(self.position_shown)
-    sound.playSfx( 'unreveal' )
-    Tween.start( self.movetime, self.position, self.position_hidden )
   end
 end
 

--- a/src/nodes/hiddendoortrigger.lua
+++ b/src/nodes/hiddendoortrigger.lua
@@ -54,10 +54,6 @@ end
 function HiddenDoorTrigger:update(dt)
 end
 
-function HiddenDoorTrigger:enter(previous)
-  Gamestate.currentState().doors[self.target].node:hide(previous)
-end
-
 function HiddenDoorTrigger:draw()
   if self.fixed or self.open then
     self.opened:draw(self.image, self.x, self.y)
@@ -82,6 +78,7 @@ function HiddenDoorTrigger:keypressed( button, player )
         if result == 'Yes' then
           Gamestate.currentState().doors[self.target].node:show()
           app.gamesaves:active():set(self.key, true)
+          self.open = true
         end
         player.freeze = false
         self.fixed = result == 'Yes'


### PR DESCRIPTION
This fixes a bug where no image for hidden doors was showing when re-entering a level.
Additionally I think it's nicer to alert the player that the door is hideable.

To test this open the fireplace in the house and then leave the level and come back.

This also slows down up the greendale door becuase it now plays the sound every time which was weird without an animation.