### PR TITLE
Prevent player from celebrating after being killed by Cornelius

### DIFF
--- a/src/nodes/enemies/benzalkBoss.lua
+++ b/src/nodes/enemies/benzalkBoss.lua
@@ -76,7 +76,7 @@ return {
 
   enter = function( enemy )
     if enemy.db:get("bosstriggers.benzalk", false) then
-      enemy:die()
+      enemy:die(true)
     end
     enemy.direction = 'left'
     enemy.state = 'default'
@@ -328,3 +328,4 @@ return {
     end
   end
 }
+


### PR DESCRIPTION
After the player respawns after being killed by Cornelius they tend to inexplicably dance, as noted [here](https://www.reddit.com/r/hawkthorne/comments/3qd4ec/what_happened_to_cornelius/). This was caused by benzalk loading and immediately calling die. This had been fixed using the hide argument of the die function which was put there for this situation.

Also this is the first pull on a new computer so excuse the file ending.