### PR TITLE
GitHub workaround for releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ CI_TARGET=test validate maps productionize binaries
 ifeq ($(TRAVIS), true)
 ifeq ($(TRAVIS_PULL_REQUEST), false)
 ifeq ($(TRAVIS_BRANCH), release)
-CI_TARGET=clean test validate maps productionize upload social
+CI_TARGET=clean test validate maps productionize social
 endif
 endif
 endif

--- a/templates/post.md
+++ b/templates/post.md
@@ -2,9 +2,9 @@
 
 **DOWNLOAD**
 
-- [OS X](http://files.projecthawkthorne.com/releases/v{version}/hawkthorne-osx.zip)
-- [Windows](http://files.projecthawkthorne.com/releases/v{version}/hawkthorne-win-x86.zip)
-- [hawkthorne.love](http://files.projecthawkthorne.com/releases/v{version}/hawkthorne.love)
+- [OS X](https://github.com/hawkthorne/hawkthorne-journey/releases/download/v{version}/hawkthorne-osx.zip)
+- [Windows](https://github.com/hawkthorne/hawkthorne-journey/releases/download/v{version}/hawkthorne-win-x86.zip)
+- [hawkthorne.love](https://github.com/hawkthorne/hawkthorne-journey/releases/download/v{version}/hawkthorne.love)
   You'll need to install the [love](http://love2d.org) framework as well.
 
 **How can I help?**


### PR DESCRIPTION
We have failures in our current releases related to pushing to GitHub. Rather than attempt to fix the problem, this just works around it by not pushing to GitHub anymore during a release and therefore releases will need to be a manual process going forward for now.