### PR TITLE
Blackjack bug fixes

### DIFF
--- a/src/blackjackgame.lua
+++ b/src/blackjackgame.lua
@@ -160,7 +160,7 @@ function state:keypressed(button, player)
     elseif self.selected == 'BET -' then -- check decrements against increments above
       local betDelta = 0
       if self.currentBet > 250  then
-        if (self.currentBet - 250)%100 == 0) then
+        if (self.currentBet - 250)%100 == 0 then
           betDelta = -100
         else
           betDelta = -((self.currentBet-250)%100) -- subtract out the portion that is not part of the standard increment


### PR DESCRIPTION
-Fixed bet increment/decrement logic. Will allow player to max out bet to available money. When decrementing the bet, will remove the portion not part of the standard decrement, if not a multiple of that decrement.

-Fixed the gameMenu logic regarding when to allow splits and double downs, as related to player money and the current wager. Existing logic would not allow a double down or split under certain conditions (e.g., when trying to double down after splitting, could not double down if player money was not at least 4x greater than the current bet, logic should actual check if player is capable of adding another currentBet to wager).

-Fixed dealer winning on blackjack even if player has blackjack. Now it's a push if player also has blackjack.