### PR TITLE
Update inputcontroller to LÖVE >0.9.2 space key

### DIFF
--- a/src/inputcontroller.lua
+++ b/src/inputcontroller.lua
@@ -15,7 +15,7 @@ local DEFAULT_ACTIONMAP = {
     RIGHT = 'right',
     SELECT = 's',
     START = 'escape',
-    JUMP = ' ',
+    JUMP = 'space',
     ATTACK = 'a',
     INTERACT = 'd',
   },

--- a/src/test/test_inputcontroller.lua
+++ b/src/test/test_inputcontroller.lua
@@ -7,7 +7,7 @@ local DEFAULT_ACTIONMAP = {
   RIGHT = 'right',
   SELECT = 's',
   START = 'escape',
-  JUMP = ' ',
+  JUMP = 'space',
   ATTACK = 'a',
   INTERACT = 'd',
 }


### PR DESCRIPTION
As of LÖVE 0.9.2, the KeyConstant for spacebar is no longer `" "` but `"space"`.

This was causing a fresh boot of the game to not register spacebar inputs on Linux (tested from Fedora 24 with LÖVE 0.10.0).

A workaround was to reset the controls from the controls menu. This just isn't very obvious as the controls menu already says "space/enter" for jump, even when space is unresponsive.

I figured since Hawkthorne targets LÖVE 0.10.0, it would be fitting to upgrade to the new space constant.