### PR TITLE
Fix misspelling of bubblegum ("bubblgum")

### DIFF
--- a/src/cheat.lua
+++ b/src/cheat.lua
@@ -44,7 +44,7 @@ local function setCheat(cheatName, turnOn)
       'pink_potion','purple_potion','red_potion','white_potion',
       'yellow_potion'}},
     give_fryables = {materials = {
-      'bubblgum','carkeys','fries','pancake','toast'}},
+      'bubblegum','carkeys','fries','pancake','toast'}},
     give_recipes = {details = {
       'blue_potion','green_potion','orange_potion','pink_potion',
       'purple_potion','red_potion','white_potion', 'yellow_potion'}},

--- a/src/items/potion_recipes.lua
+++ b/src/items/potion_recipes.lua
@@ -76,17 +76,17 @@ return {
   },
   {
   --chicken finger
-    recipe       = {pancake = 1, banana = 1, toast = 1, bubblgum = 1, carkeys = 1},
+    recipe       = {pancake = 1, banana = 1, toast = 1, bubblegum = 1, carkeys = 1},
     name         = 'chickenfinger',
   },
   {
   --chewy iron crepe
-    recipe       = {pancake = 1, bubblgum = 3, carkeys = 3},
+    recipe       = {pancake = 1, bubblegum = 3, carkeys = 3},
     name         = 'ironcrepe',
   },
   {
   --gummy keynana
-    recipe       = {banana = 1, bubblgum = 6, carkeys = 3},
+    recipe       = {banana = 1, bubblegum = 6, carkeys = 3},
     name         = 'keynana',
   }
 }


### PR DESCRIPTION
'Bubblegum' is currently spelled 'bubblgum', and this misspelling is causing crashes: https://www.reddit.com/r/hawkthorne/comments/95clnx/i_found_a_glitch_in_the_cheats_menu_this_message/