### PR TITLE
Addresses two common collision issues

### DIFF
--- a/src/hawk/collision.lua
+++ b/src/hawk/collision.lua
@@ -323,7 +323,9 @@ function module.move_y(map, player, x, y, width, height, dx, dy)
           -- will never be dropping when standing on a block  
           player.platform_dropping = false
           -- If the block is sloped, interpolate the y value to be correct
-          if slope_y <= (new_y + height - tile_slope * dx + 2) and (slope_y >= y + height or not special) then
+          -- If slope_y < new_y, it's above our current position, which doesn't make sense if we're moving down
+          --    if you were to return slope_y - height in that case, then the player would warp upwards, potentially clipping into the geometry
+          if slope_y >= new_y and slope_y <= (new_y + height - tile_slope * dx + 2) and (slope_y >= y + height or not special) then
             if player.floor_pushback then
               player:floor_pushback(tile)
             end

--- a/src/level.lua
+++ b/src/level.lua
@@ -726,7 +726,7 @@ function Level:keypressed( button )
     end
   end
 
-  if self.player:keypressed( button, self ) then
+  if self.player:keypressed( button, self.map ) then
     return true
   end
 


### PR DESCRIPTION
The first is when you attack soon after crouching. If you timed it just right, attacking just before you went under a low ceiling would cause you to stand up and clip into the ceiling.

The second, which is related to the first, would happen if you stood up right at the edge of a ceiling. The code would find a tile above the character instead of below, since even when standing still, gravity causes the collision code to run assuming you're falling down.

Both of these situations are easiest to reproduce when on a moving platform.

I tested this extensively with `--level=black-caverns-2 --cheat=give_master_key`: 

- Jump onto the moving platform  
- Right before you pass under the edge of the ceiling, crouch -> stand -> attack  
- Another test is to hit down + up very fast right near the edge too

*I'd suggest trying to cause it in the current version of the game, so you get the key presses that cause the issue*  

Attempts to address #2578 and #2456.

For #2578, I'm not sure how to have a repeatable test with being hit by a bat to knock you into the ceiling.

Also note that I'm testing at 144FPS and I think it's easier to reproduce at a lower framerate.