### PR TITLE
love.js v11.5 and relative dependency loading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,12 @@ love.js: build/hawkthorne.love
 	mkdir -p build/web
 	npm install
 	npx love.js -t "Journey to the Center of Hawkthorne" -m 77594624 -c build/hawkthorne.love build/web
+	######## Temporary LÖVE v11.5 until new version is published on NPM ########
+	$(WGET) https://github.com/Davidobot/love.js/raw/refs/heads/master/src/compat/love.js
+	$(WGET) https://github.com/Davidobot/love.js/raw/refs/heads/master/src/compat/love.wasm
+	mv love.js build/web/
+	mv love.wasm build/web/
+	################################### END ####################################
 	cp templates/web/* build/web/
 
 build/hawkthorne.love: $(TILEMAPS) src/*

--- a/templates/web/index.html
+++ b/templates/web/index.html
@@ -24,7 +24,7 @@
     <script src="love-game.js" type="module" defer></script>
   </head>
   <body>
-    <love-game>
+    <love-game data-memory="77594624">
       <canvas id="canvas" width="1056" height="672"></canvas>
       <noscript>
         Sorry, this game requires JavaScript.

--- a/templates/web/love-game.js
+++ b/templates/web/love-game.js
@@ -4,7 +4,10 @@ class LoveGame extends HTMLElement {
   constructor() {
     super();
 
-    this.LIBRARIES = ["assets/js/game.js", "assets/js/love.js"];
+    this.LIBRARIES = [
+      new URL("game.js", import.meta.url),
+      new URL("love.js", import.meta.url)
+    ];
   }
 
   connectedCallback() {
@@ -32,16 +35,17 @@ class LoveGame extends HTMLElement {
   init() {
     this.Module = {
       arguments: ["./game.love"],
-      INITIAL_MEMORY: 77594624,
+      filePackagePrefixURL: new URL("game.data", import.meta.url).href.replace(/game.data$/, ""),
+      INITIAL_MEMORY: parseInt(this.dataset.memory),
       printErr: console.error.bind(console),
       canvas: (() => {
-        const canvas = document.getElementById('canvas');
+        const canvas = this.querySelector("#canvas");
 
         // As a default initial behavior, pop up an alert when webgl context is lost. To make your
         // application robust, you may want to override this behavior before shipping!
         // See http://www.khronos.org/registry/webgl/specs/latest/1.0/#5.15.2
         canvas.addEventListener("webglcontextlost", function(e) {
-          alert('WebGL context lost. You will need to reload the page.');
+          alert("WebGL context lost. You will need to reload the page.");
           e.preventDefault();
         }, false);
 
@@ -62,9 +66,9 @@ class LoveGame extends HTMLElement {
         this.Module.remainingDependencies = left;
         this.Module.totalDependencies = Math.max(this.Module.totalDependencies, left);
         if (left) {
-          this.Module.setStatus('Preparing... (' + (this.Module.totalDependencies - left) + '/' + this.Module.totalDependencies + ')');
+          this.Module.setStatus("Preparing... (" + (this.Module.totalDependencies - left) + "/" + this.Module.totalDependencies + ")");
         } else {
-          this.Module.setStatus('All downloads complete.');
+          this.Module.setStatus("All downloads complete.");
           this.pregameContainer.remove();
         }
       }
@@ -87,13 +91,13 @@ class LoveGame extends HTMLElement {
 
         window.onerror = (event) => {
           // TODO: do not warn on ok events like simulating an infinite loop or exitStatus
-          this.Module.setStatus('Exception thrown, see JavaScript console');
+          this.Module.setStatus("Exception thrown, see JavaScript console");
           this.Module.setStatus = function(text) {
-            if (text) Module.printErr('[post-exception status] ' + text);
+            if (text) Module.printErr("[post-exception status] " + text);
           };
         };
 
-        this.Module.setStatus('Downloading...');
+        this.Module.setStatus("Downloading...");
         Love(this.Module);
       },
       err => {throw new Error("Unable to load necessary libraries", { cause: err })}
@@ -112,8 +116,8 @@ class LoveGame extends HTMLElement {
         });
         return;
       }
-      let script = document.createElement('script');
-      script.type = 'text/javascript';
+      let script = document.createElement("script");
+      script.type = "text/javascript";
       script.async = true;
       script.src = url;
 


### PR DESCRIPTION
[love.js](https://github.com/Davidobot/love.js) does have full support for v11.5, but it hasn't been published to NPM yet. In the meantime I have a temporary workaround where we download `love.js` and `love.wasm` directly from the repository.

I've also updated `love-game.js` to support relative URL dependency loading.